### PR TITLE
Add transaction support for tRFC, qRFC, and bgRFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ examples/**/Config.toml
 
 # Environment files
 *.env
+*.dylib
+*.jar.bak

--- a/README.md
+++ b/README.md
@@ -143,6 +143,52 @@ public function main() returns error? {
 }
 ```
 
+#### Execute a Function Module as a transactional RFC (tRFC)
+
+A tRFC call is executed exactly once on the SAP backend, and is tracked by a transaction ID (TID).
+If the send fails, retry with the same TID (available in the `TransactionError` detail) to keep
+the exactly-once guarantee.
+
+```ballerina
+public function main() returns error? {
+    string tid = check jcoClient->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": [{"LINE": "Hello from Ballerina tRFC"}]});
+    io:println("Sent with TID: ", tid);
+}
+```
+
+#### Execute a Function Module as a queued RFC (qRFC)
+
+qRFC extends tRFC with exactly-once-in-order semantics: calls sent to the same inbound queue are
+processed serially in the order they were sent.
+
+```ballerina
+public function main() returns error? {
+    string tid = check jcoClient->sendQRfc("STFC_WRITE_TO_TCPIC", "MY_INBOUND_QUEUE",
+            {"TCPICDAT": [{"LINE": "Hello from Ballerina qRFC"}]});
+    io:println("Queued with TID: ", tid);
+}
+```
+
+#### Send a bgRFC unit (type T or type Q)
+
+bgRFC bundles one or more function calls into a single logical unit of work. Without queue names
+the unit is type T (exactly-once); with queue names it is type Q (exactly-once-in-order). The
+state of a unit can be queried and confirmed through the client.
+
+```ballerina
+public function main() returns error? {
+    jco:BgRfcUnitInfo unit = check jcoClient->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": [{"LINE": "bgRFC call 1"}]}},
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": [{"LINE": "bgRFC call 2"}]}}
+    ], {unitHistory: true});
+    io:println("Committed bgRFC unit: ", unit.unitId, " type: ", unit.unitType);
+
+    jco:BgRfcUnitState state = check jcoClient->getBgRfcUnitState(unit);
+    io:println("Unit state: ", state);
+}
+```
+
 #### Initialize a listener for incoming IDocs
 
 ```ballerina

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.9.1"
+distribution-version = "2201.13.4"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.7.2"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -35,6 +35,25 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
+name = "lang.array"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.__internal"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.error"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 dependencies = [
@@ -50,8 +69,34 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
+name = "lang.runtime"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
+]
+modules = [
+	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
+]
+
+[[package]]
+org = "ballerina"
+name = "test"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.array"},
+	{org = "ballerina", name = "lang.error"}
+]
+modules = [
+	{org = "ballerina", packageName = "test", moduleName = "test"}
+]
+
+[[package]]
+org = "ballerina"
 name = "time"
-version = "2.4.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -62,7 +107,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.8.0"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -79,6 +124,8 @@ name = "sap.jco"
 version = "0.1.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.runtime"},
+	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "uuid"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.4"
+distribution-version = "2201.9.1"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.12.1"
+version = "2.7.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -35,25 +35,6 @@ dependencies = [
 
 [[package]]
 org = "ballerina"
-name = "lang.array"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.__internal"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.error"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
 name = "lang.int"
 version = "0.0.0"
 dependencies = [
@@ -69,34 +50,8 @@ version = "0.0.0"
 
 [[package]]
 org = "ballerina"
-name = "lang.runtime"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
-]
-modules = [
-	{org = "ballerina", packageName = "lang.runtime", moduleName = "lang.runtime"}
-]
-
-[[package]]
-org = "ballerina"
-name = "test"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.array"},
-	{org = "ballerina", name = "lang.error"}
-]
-modules = [
-	{org = "ballerina", packageName = "test", moduleName = "test"}
-]
-
-[[package]]
-org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.4.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -107,7 +62,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "uuid"
-version = "1.10.0"
+version = "1.8.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -124,8 +79,6 @@ name = "sap.jco"
 version = "0.1.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.runtime"},
-	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "uuid"}
 ]

--- a/ballerina/Module.md
+++ b/ballerina/Module.md
@@ -137,6 +137,52 @@ public function main() returns error? {
 }
 ```
 
+#### Execute a Function Module as a transactional RFC (tRFC)
+
+A tRFC call is executed exactly once on the SAP backend, and is tracked by a transaction ID (TID).
+If the send fails, retry with the same TID (available in the `TransactionError` detail) to keep
+the exactly-once guarantee.
+
+```ballerina
+public function main() returns error? {
+    string tid = check jcoClient->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": [{"LINE": "Hello from Ballerina tRFC"}]});
+    io:println("Sent with TID: ", tid);
+}
+```
+
+#### Execute a Function Module as a queued RFC (qRFC)
+
+qRFC extends tRFC with exactly-once-in-order semantics: calls sent to the same inbound queue are
+processed serially in the order they were sent.
+
+```ballerina
+public function main() returns error? {
+    string tid = check jcoClient->sendQRfc("STFC_WRITE_TO_TCPIC", "MY_INBOUND_QUEUE",
+            {"TCPICDAT": [{"LINE": "Hello from Ballerina qRFC"}]});
+    io:println("Queued with TID: ", tid);
+}
+```
+
+#### Send a bgRFC unit (type T or type Q)
+
+bgRFC bundles one or more function calls into a single logical unit of work. Without queue names
+the unit is type T (exactly-once); with queue names it is type Q (exactly-once-in-order). The
+state of a unit can be queried and confirmed through the client.
+
+```ballerina
+public function main() returns error? {
+    jco:BgRfcUnitInfo unit = check jcoClient->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": [{"LINE": "bgRFC call 1"}]}},
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": [{"LINE": "bgRFC call 2"}]}}
+    ], {unitHistory: true});
+    io:println("Committed bgRFC unit: ", unit.unitId, " type: ", unit.unitType);
+
+    jco:BgRfcUnitState state = check jcoClient->getBgRfcUnitState(unit);
+    io:println("Unit state: ", state);
+}
+```
+
 #### Initialize a listener for incoming IDocs
 
 ```ballerina

--- a/ballerina/Package.md
+++ b/ballerina/Package.md
@@ -137,6 +137,52 @@ public function main() returns error? {
 }
 ```
 
+#### Execute a Function Module as a transactional RFC (tRFC)
+
+A tRFC call is executed exactly once on the SAP backend, and is tracked by a transaction ID (TID).
+If the send fails, retry with the same TID (available in the `TransactionError` detail) to keep
+the exactly-once guarantee.
+
+```ballerina
+public function main() returns error? {
+    string tid = check jcoClient->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": [{"LINE": "Hello from Ballerina tRFC"}]});
+    io:println("Sent with TID: ", tid);
+}
+```
+
+#### Execute a Function Module as a queued RFC (qRFC)
+
+qRFC extends tRFC with exactly-once-in-order semantics: calls sent to the same inbound queue are
+processed serially in the order they were sent.
+
+```ballerina
+public function main() returns error? {
+    string tid = check jcoClient->sendQRfc("STFC_WRITE_TO_TCPIC", "MY_INBOUND_QUEUE",
+            {"TCPICDAT": [{"LINE": "Hello from Ballerina qRFC"}]});
+    io:println("Queued with TID: ", tid);
+}
+```
+
+#### Send a bgRFC unit (type T or type Q)
+
+bgRFC bundles one or more function calls into a single logical unit of work. Without queue names
+the unit is type T (exactly-once); with queue names it is type Q (exactly-once-in-order). The
+state of a unit can be queried and confirmed through the client.
+
+```ballerina
+public function main() returns error? {
+    jco:BgRfcUnitInfo unit = check jcoClient->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": [{"LINE": "bgRFC call 1"}]}},
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": [{"LINE": "bgRFC call 2"}]}}
+    ], {unitHistory: true});
+    io:println("Committed bgRFC unit: ", unit.unitId, " type: ", unit.unitType);
+
+    jco:BgRfcUnitState state = check jcoClient->getBgRfcUnitState(unit);
+    io:println("Unit state: ", state);
+}
+```
+
 #### Initialize a listener for incoming IDocs
 
 ```ballerina

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -62,7 +62,7 @@ public isolated client class Client {
     # the same TID until it succeeds, then confirm. A confirmed TID must not be reused - the
     # backend forgets it, so a resend under it would execute again.
     #
-    # + tid - The TID to confirm.
+    # + tid - The TID to confirm. Must be exactly 24 characters long.
     # + return - An error if the confirmation fails.
     isolated remote function confirmTid(string tid) returns Error? = @java:Method {
         'class: "io.ballerina.lib.sap.Transactions"
@@ -77,6 +77,8 @@ public isolated client class Client {
     # + functionName - The name of the RFC-enabled function module to execute.
     # + importParams - The import, changing, and table parameters for the function.
     # + tid - The transaction ID to use. If not given, a new TID is created automatically.
+    #         A supplied TID must be exactly 24 characters long; its content is otherwise
+    #         unrestricted, so it may be derived from an application idempotency key.
     # + autoConfirm - If true, the TID is confirmed automatically after a successful send
     #                 (best-effort: a failed confirmation is logged but not surfaced, since
     #                 the call was already delivered). Set to false to confirm manually via
@@ -97,6 +99,8 @@ public isolated client class Client {
     # + queueName - The name of the SAP inbound queue to place the call on.
     # + importParams - The import, changing, and table parameters for the function.
     # + tid - The transaction ID to use. If not given, a new TID is created automatically.
+    #         A supplied TID must be exactly 24 characters long; its content is otherwise
+    #         unrestricted, so it may be derived from an application idempotency key.
     # + autoConfirm - If true, the TID is confirmed automatically after a successful send
     #                 (best-effort: a failed confirmation is logged but not surfaced, since
     #                 the call was already delivered). Set to false to confirm manually via

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -48,6 +48,101 @@ public isolated client class Client {
         'class: "io.ballerina.lib.sap.Client"
     } external;
 
+    # Creates a new transaction ID (TID) from the SAP backend for use with tRFC/qRFC calls.
+    # Holding on to the TID before sending allows retrying a failed send with the same TID,
+    # which guarantees exactly-once execution.
+    #
+    # + return - The TID, or an error if the creation fails.
+    isolated remote function createTid() returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Confirms a transaction ID (TID) so the SAP backend can clean up its bookkeeping for it.
+    # Use this together with `autoConfirm = false` on `sendTRfc`/`sendQRfc`: retry the send with
+    # the same TID until it succeeds, then confirm. A confirmed TID must not be reused - the
+    # backend forgets it, so a resend under it would execute again.
+    #
+    # + tid - The TID to confirm.
+    # + return - An error if the confirmation fails.
+    isolated remote function confirmTid(string tid) returns Error? = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Executes the RFC function as a transactional RFC (tRFC) with exactly-once semantics.
+    # The call is asynchronous on the SAP side, so no result is returned. If the send fails,
+    # the returned `TransactionError` carries the TID in its detail; retrying with that TID
+    # keeps exactly-once semantics (use `autoConfirm = false` for such retry flows and call
+    # `confirmTid` after the send finally succeeds).
+    #
+    # + functionName - The name of the RFC-enabled function module to execute.
+    # + importParams - The import, changing, and table parameters for the function.
+    # + tid - The transaction ID to use. If not given, a new TID is created automatically.
+    # + autoConfirm - If true, the TID is confirmed automatically after a successful send
+    #                 (best-effort: a failed confirmation is logged but not surfaced, since
+    #                 the call was already delivered). Set to false to confirm manually via
+    #                 `confirmTid`.
+    # + return - The TID under which the call was sent, or an error if the send fails.
+    isolated remote function sendTRfc(string functionName, ParamStructure importParams = {},
+            string? tid = (), boolean autoConfirm = true) returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Executes the RFC function as a queued RFC (qRFC) with exactly-once-in-order semantics.
+    # Calls sent to the same inbound queue are processed serially in the order they were sent.
+    # If the send fails, the returned `TransactionError` carries the TID in its detail;
+    # retrying with that TID keeps exactly-once semantics (use `autoConfirm = false` for such
+    # retry flows and call `confirmTid` after the send finally succeeds).
+    #
+    # + functionName - The name of the RFC-enabled function module to execute.
+    # + queueName - The name of the SAP inbound queue to place the call on.
+    # + importParams - The import, changing, and table parameters for the function.
+    # + tid - The transaction ID to use. If not given, a new TID is created automatically.
+    # + autoConfirm - If true, the TID is confirmed automatically after a successful send
+    #                 (best-effort: a failed confirmation is logged but not surfaced, since
+    #                 the call was already delivered). Set to false to confirm manually via
+    #                 `confirmTid`.
+    # + return - The TID under which the call was sent, or an error if the send fails.
+    isolated remote function sendQRfc(string functionName, string queueName,
+            ParamStructure importParams = {}, string? tid = (), boolean autoConfirm = true)
+            returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Sends one or more function calls to SAP as a single bgRFC unit (one logical unit of work).
+    # If `queueNames` is set in the unit configuration, the unit is sent as type Q (bg-qRFC,
+    # exactly-once-in-order); otherwise as type T (exactly-once).
+    #
+    # + functionCalls - The function invocations that make up the unit. All of them are
+    #                   executed in one logical unit of work on the SAP backend.
+    # + unitConfig - The configurations for the unit.
+    # + return - The ID and type of the committed unit, or an error if the commit fails.
+    isolated remote function sendBgRfcUnit(FunctionCall[] functionCalls, BgRfcUnitConfig unitConfig = {})
+            returns BgRfcUnitInfo|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Retrieves the processing state of a bgRFC unit from the SAP backend. `COMMITTED` means
+    # the backend finished processing the unit and it can be confirmed; `CONFIRMED` means it
+    # was already confirmed via `confirmBgRfcUnit`.
+    #
+    # + unit - The unit identification returned by `sendBgRfcUnit`.
+    # + return - The state of the unit, or an error if the lookup fails.
+    isolated remote function getBgRfcUnitState(BgRfcUnitInfo unit)
+            returns BgRfcUnitState|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Confirms a bgRFC unit so the SAP backend can delete its status information for the unit.
+    # Confirm once `getBgRfcUnitState` reports `COMMITTED` (processing finished); after the
+    # confirmation the state becomes `CONFIRMED`. A confirmed unit ID must not be reused.
+    #
+    # + unit - The unit identification returned by `sendBgRfcUnit`.
+    # + return - An error if the confirmation fails.
+    isolated remote function confirmBgRfcUnit(BgRfcUnitInfo unit)
+            returns Error? = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
 }
 
 isolated function initializeClient(Client jcoClient, DestinationConfig configurations, string destinationId, boolean setImportParamNull) returns Error? = @java:Method {

--- a/ballerina/tests/transaction_advanced_tests.bal
+++ b/ballerina/tests/transaction_advanced_tests.bal
@@ -19,6 +19,7 @@
 // assumptions (for example: SAP silently accepts the confirmation of a TID it never issued).
 
 import ballerina/test;
+import ballerina/time;
 import ballerina/uuid;
 
 // --- Identifier validation (no SAP round trip needed for the rejection itself) ---
@@ -162,6 +163,52 @@ function testImportAndTableParametersTogether() returns error? {
         "TCPICDAT": tcpicRows("IMPORTPARAM")
     });
     test:assertTrue(tid.length() > 0);
+}
+
+@test:Config {enable: enableLiveTests}
+function testFullyTypedStructureAndTable() returns error? {
+    // STFC_STRUCTURE takes the RFCTEST structure, which covers every ABAP type the
+    // connector converts: FLTP, INT1, INT2, INT4, RAW, DATS, TIMS and CHAR. The structure
+    // goes to the IMPORT list and the table of the same type to the TABLES list, so one
+    // call exercises the whole of ParameterProcessor.
+    Client sap = check getTestClient();
+    time:Date postingDate = {year: 2026, month: 8, day: 18};
+    ParamStructure postingTime = {
+        "year": 2026,
+        "month": 8,
+        "day": 18,
+        "hour": 14,
+        "minute": 5,
+        "second": 12
+    };
+    ParamStructure row = {
+        "RFCFLOAT": 1250.75,
+        "RFCCHAR1": "R",
+        // STFC_STRUCTURE's ABAP body increments the numeric fields of RFCTABLE, so the
+        // values stay clear of the ABAP type limits (INT1 is 0-255, INT2 is signed 16-bit).
+        "RFCINT1": 100,
+        "RFCINT2": 32000,
+        "RFCINT4": 2147483000,
+        "RFCCHAR2": "KG",
+        "RFCCHAR4": "1010",
+        "RFCHEX3": <byte[]>[0xA1, 0xB2, 0xC3],
+        "RFCDATE": postingDate,
+        "RFCTIME": postingTime,
+        "RFCDATA1": "MAT-1000",
+        "RFCDATA2": testMarker
+    };
+
+    string tid = check sap->sendTRfc("STFC_STRUCTURE", {"IMPORTSTRUCT": row, "RFCTABLE": [row, row]});
+    test:assertTrue(tid.length() > 0, "a fully typed structure and table must be accepted");
+}
+
+@test:Config {enable: enableLiveTests}
+function testChangingParameterRouting() returns error? {
+    // STFC_CHANGING exposes COUNTER as a CHANGING parameter and START_VALUE as an IMPORT
+    // parameter, so this is the only call shape that exercises the changing-list branch.
+    Client sap = check getTestClient();
+    string tid = check sap->sendTRfc("STFC_CHANGING", {"START_VALUE": 10, "COUNTER": 5});
+    test:assertTrue(tid.length() > 0, "a changing parameter must be routed and accepted");
 }
 
 // --- Concurrency ---

--- a/ballerina/tests/transaction_advanced_tests.bal
+++ b/ballerina/tests/transaction_advanced_tests.bal
@@ -22,18 +22,35 @@ import ballerina/test;
 import ballerina/time;
 import ballerina/uuid;
 
-// --- Identifier validation (no SAP round trip needed for the rejection itself) ---
+// --- Identifier validation ---
 
 @test:Config {enable: enableLiveTests}
-function testSendTRfcRejectsMalformedTid() returns error? {
+function testSendTRfcRejectsWrongLengthTid() returns error? {
+    // Shorter than 24 characters is split out of bounds by JCo; longer is silently truncated,
+    // which would record a different identifier than the caller believes it used.
     Client sap = check getTestClient();
-    string|Error result = sap->sendTRfc("STFC_WRITE_TO_TCPIC",
-            {"TCPICDAT": tcpicRows("BADTID")}, "NOT-A-VALID-TID");
-    test:assertTrue(result is Error, "a malformed TID must be rejected");
-    if result is Error {
-        test:assertTrue(result.message().includes("24-character hexadecimal"),
-                "the error must explain the required TID format, got: " + result.message());
+    foreach string bad in ["NOT-A-VALID-TID", "0A0018D5CB206A8405D20000EXTRA"] {
+        string|Error result = sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+                {"TCPICDAT": tcpicRows("BADTID")}, bad);
+        test:assertTrue(result is Error, string `TID '${bad}' must be rejected`);
+        if result is Error {
+            test:assertTrue(result.message().includes("exactly 24 characters"),
+                    "the error must explain the required TID length, got: " + result.message());
+        }
     }
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendTRfcAcceptsNonHexTidOfCorrectLength() returns error? {
+    // SAP stores the TID components as CHAR, so an application may derive a TID from its own
+    // idempotency key. Only the length matters - rejecting these would break that pattern.
+    Client sap = check getTestClient();
+    string businessTid = "IDEMPOTENCY-KEY-" + testMarker.substring(testMarker.length() - 8);
+    test:assertEquals(businessTid.length(), 24, "the test's own fixture must be 24 characters");
+    string used = check sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": tcpicRows("BIZTID")}, businessTid, autoConfirm = false);
+    test:assertEquals(used, businessTid, "a 24-character non-hex TID must be usable");
+    check sap->confirmTid(businessTid);
 }
 
 @test:Config {enable: enableLiveTests}
@@ -99,6 +116,11 @@ function testExplicitUnitIdIsHonoured() returns error? {
         {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("EXPLICIT-UNITID")}}
     ], {unitId: wanted, unitHistory: true});
     test:assertEquals(again.unitId, wanted);
+
+    // The assertions above are satisfied locally by JCo echoing the ID back, so query the
+    // backend as well: a unit it has actually accepted must not report NOT_FOUND.
+    BgRfcUnitState state = check waitForUnitProcessing(sap, unit);
+    test:assertNotEquals(state, NOT_FOUND, "SAP must know the unit that was committed under this ID");
 }
 
 @test:Config {enable: enableLiveTests}
@@ -122,6 +144,10 @@ function testUnitAttributesAccepted() returns error? {
         unitHistory: true
     });
     test:assertEquals(unit.unitId.length(), 32);
+    // A generated ID is 32 characters regardless, so confirm the backend accepted the unit
+    // carrying these attributes.
+    BgRfcUnitState state = check waitForUnitProcessing(sap, unit);
+    test:assertNotEquals(state, NOT_FOUND, "a unit sent with attributes must exist on the backend");
 }
 
 // --- Parameter handling ---

--- a/ballerina/tests/transaction_advanced_tests.bal
+++ b/ballerina/tests/transaction_advanced_tests.bal
@@ -1,0 +1,202 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Extended coverage for the transactional API. The expectations here were established by
+// probing a live SAP system first, so they assert observed backend behaviour rather than
+// assumptions (for example: SAP silently accepts the confirmation of a TID it never issued).
+
+import ballerina/test;
+import ballerina/uuid;
+
+// --- Identifier validation (no SAP round trip needed for the rejection itself) ---
+
+@test:Config {enable: enableLiveTests}
+function testSendTRfcRejectsMalformedTid() returns error? {
+    Client sap = check getTestClient();
+    string|Error result = sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": tcpicRows("BADTID")}, "NOT-A-VALID-TID");
+    test:assertTrue(result is Error, "a malformed TID must be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("24-character hexadecimal"),
+                "the error must explain the required TID format, got: " + result.message());
+    }
+}
+
+@test:Config {enable: enableLiveTests}
+function testConfirmTidRejectsMalformedTid() returns error? {
+    Client sap = check getTestClient();
+    Error? result = sap->confirmTid("XYZ");
+    test:assertTrue(result is Error, "a malformed TID must be rejected");
+}
+
+@test:Config {enable: enableLiveTests}
+function testBgRfcRejectsMalformedUnitId() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo malformed = {unitId: "TOO-SHORT", unitType: BGRFC_TYPE_T};
+    BgRfcUnitState|Error state = sap->getBgRfcUnitState(malformed);
+    test:assertTrue(state is Error, "a malformed unit ID must be rejected");
+    if state is Error {
+        test:assertTrue(state.message().includes("32-character hexadecimal"), state.message());
+    }
+}
+
+// --- Identifier lifecycle edge cases (behaviour confirmed against the live system) ---
+
+@test:Config {enable: enableLiveTests}
+function testUnknownUnitStateIsNotFound() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo phantom = {unitId: newUnitId(), unitType: BGRFC_TYPE_T};
+    BgRfcUnitState state = check sap->getBgRfcUnitState(phantom);
+    test:assertEquals(state, NOT_FOUND, "a unit that was never sent must report NOT_FOUND");
+}
+
+@test:Config {enable: enableLiveTests}
+function testConfirmTidIsIdempotent() returns error? {
+    Client sap = check getTestClient();
+    string tid = check sap->createTid();
+    check sap->confirmTid(tid);
+    // SAP accepts a repeated confirmation rather than failing.
+    check sap->confirmTid(tid);
+}
+
+@test:Config {enable: enableLiveTests}
+function testEmptyBgRfcUnitRejected() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo|Error result = sap->sendBgRfcUnit([]);
+    test:assertTrue(result is Error, "a unit with no function calls must be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("at least one function call"), result.message());
+    }
+}
+
+// --- bgRFC unit configuration ---
+
+@test:Config {enable: enableLiveTests}
+function testExplicitUnitIdIsHonoured() returns error? {
+    Client sap = check getTestClient();
+    string wanted = newUnitId();
+    BgRfcUnitInfo unit = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("EXPLICIT-UNITID")}}
+    ], {unitId: wanted, unitHistory: true});
+    test:assertEquals(unit.unitId, wanted, "the requested unit ID must be used");
+
+    // Re-committing the same unit ID is accepted, and SAP executes the payload only once.
+    BgRfcUnitInfo again = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("EXPLICIT-UNITID")}}
+    ], {unitId: wanted, unitHistory: true});
+    test:assertEquals(again.unitId, wanted);
+}
+
+@test:Config {enable: enableLiveTests}
+function testMultipleQueueNamesProduceTypeQ() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo unit = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("MULTIQ")}}
+    ], {queueNames: [queueName + "_A", queueName + "_B"], unitHistory: true});
+    test:assertEquals(unit.unitType, BGRFC_TYPE_Q, "queue names must make the unit type Q");
+}
+
+@test:Config {enable: enableLiveTests}
+function testUnitAttributesAccepted() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo unit = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("ATTRS")}}
+    ], {
+        programName: "BAL_TEST_PROG",
+        transactionCode: "SE38",
+        commitCheck: true,
+        unitHistory: true
+    });
+    test:assertEquals(unit.unitId.length(), 32);
+}
+
+// --- Parameter handling ---
+
+@test:Config {enable: enableLiveTests}
+function testMultiRowTableParameter() returns error? {
+    Client sap = check getTestClient();
+    ParamStructure[] rows = [];
+    foreach int i in 1 ... 5 {
+        rows.push({"LINE": string `${testMarker}-MULTIROW-${i}`});
+    }
+    string tid = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"TCPICDAT": rows});
+    test:assertTrue(tid.length() > 0);
+}
+
+@test:Config {enable: enableLiveTests}
+function testEmptyTableParameter() returns error? {
+    Client sap = check getTestClient();
+    ParamStructure[] rows = [];
+    string tid = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"TCPICDAT": rows});
+    test:assertTrue(tid.length() > 0, "an empty table must be accepted");
+}
+
+@test:Config {enable: enableLiveTests}
+function testUnicodePayload() returns error? {
+    Client sap = check getTestClient();
+    string line = string `${testMarker}-UNI-\u{0DC3}\u{0DD2}\u{0D82}-\u{4F60}\u{597D}`;
+    string tid = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"TCPICDAT": [{"LINE": line}]});
+    test:assertTrue(tid.length() > 0);
+}
+
+@test:Config {enable: enableLiveTests}
+function testImportAndTableParametersTogether() returns error? {
+    // RESTART_QNAME is an IMPORT parameter while TCPICDAT is a TABLES parameter, so this
+    // exercises routing a single call across two different parameter lists.
+    Client sap = check getTestClient();
+    string tid = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {
+        "RESTART_QNAME": queueName + "_RESTART",
+        "TCPICDAT": tcpicRows("IMPORTPARAM")
+    });
+    test:assertTrue(tid.length() > 0);
+}
+
+// --- Concurrency ---
+
+@test:Config {enable: enableLiveTests}
+function testConcurrentSendsThroughOneClient() returns error? {
+    Client sap = check getTestClient();
+    future<string|Error> f1 = start sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": tcpicRows("CONC-1")});
+    future<string|Error> f2 = start sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": tcpicRows("CONC-2")});
+    future<string|Error> f3 = start sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": tcpicRows("CONC-3")});
+    future<string|Error> f4 = start sap->sendTRfc("STFC_WRITE_TO_TCPIC",
+            {"TCPICDAT": tcpicRows("CONC-4")});
+
+    string tid1 = check wait f1;
+    string tid2 = check wait f2;
+    string tid3 = check wait f3;
+    string tid4 = check wait f4;
+
+    map<int> uniqueTids = {};
+    foreach string tid in [tid1, tid2, tid3, tid4] {
+        uniqueTids[tid] = 1;
+    }
+    test:assertEquals(uniqueTids.length(), 4, "concurrent sends must each get their own TID");
+}
+
+isolated function newUnitId() returns string {
+    string raw = uuid:createType4AsString();
+    string id = "";
+    foreach string:Char c in raw {
+        if c != "-" {
+            id += c;
+        }
+    }
+    return id.toUpperAscii();
+}

--- a/ballerina/tests/transaction_tests.bal
+++ b/ballerina/tests/transaction_tests.bal
@@ -1,0 +1,214 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.runtime;
+import ballerina/test;
+import ballerina/time;
+
+// Live tests run only when a reachable SAP system is configured via Config.toml.
+configurable boolean enableLiveTests = false;
+configurable string host = "";
+configurable string systemNumber = "00";
+configurable string jcoClient = "800";
+configurable string user = "";
+configurable string password = "";
+configurable string queueName = "BALLERINA_TEST_QUEUE";
+
+final string testMarker = string `BAL-${time:utcNow()[0]}`;
+
+Client? sharedClient = ();
+
+// One client is shared across tests; testMultipleClients proves that additional
+// clients can coexist (single shared JCo DestinationDataProvider).
+function getTestClient() returns Client|error {
+    Client? existing = sharedClient;
+    if existing is Client {
+        return existing;
+    }
+    Client created = check new ({host, systemNumber, jcoClient, user, password});
+    sharedClient = created;
+    return created;
+}
+
+isolated function tcpicRows(string suffix) returns ParamStructure[] {
+    return [{"LINE": string `${testMarker}-${suffix}`}];
+}
+
+// --- Always-on tests (no SAP system required): guard the Java/Ballerina string contract ---
+
+@test:Config {}
+function testBgRfcTypeAndStateContract() {
+    test:assertEquals(<string>BGRFC_TYPE_T, "T");
+    test:assertEquals(<string>BGRFC_TYPE_Q, "Q");
+    test:assertEquals(<string>NOT_FOUND, "NOT_FOUND");
+    test:assertEquals(<string>IN_PROCESS, "IN_PROCESS");
+    test:assertEquals(<string>COMMITTED, "COMMITTED");
+    test:assertEquals(<string>CONFIRMED, "CONFIRMED");
+    test:assertEquals(<string>ROLLED_BACK, "ROLLED_BACK");
+}
+
+@test:Config {}
+function testBgRfcUnitConfigDefaults() {
+    BgRfcUnitConfig config = {};
+    test:assertEquals(config.queueNames, <string[]>[]);
+    test:assertFalse(config.'lock);
+    test:assertFalse(config.unitHistory);
+    test:assertFalse(config.kernelTrace);
+    test:assertFalse(config.commitCheck);
+    test:assertTrue(config.unitId is ());
+}
+
+// --- Live tests ---
+
+@test:Config {enable: enableLiveTests}
+function testMultipleClients() returns error? {
+    // Regression test: creating a second client must not fail with
+    // "DestinationDataProvider already registered".
+    Client first = check getTestClient();
+    Client second = check new ({host, systemNumber, jcoClient, user, password});
+    string tid = check second->createTid();
+    test:assertTrue(tid.length() > 0);
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendTRfcWithAutoTid() returns error? {
+    Client sap = check getTestClient();
+    string tid = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"TCPICDAT": tcpicRows("TRFC-AUTO")});
+    test:assertTrue(tid.length() > 0, "expected a non-empty TID");
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendTRfcExactlyOnceRetry() returns error? {
+    // The core exactly-once guarantee: sending twice under the SAME unconfirmed TID
+    // must execute only once on the backend. (Data-level proof: exactly one
+    // '-TRFC-RETRY' row for this run's marker in table TCPIC, checked by the
+    // external verifier.) Manual confirmation finishes the protocol and also
+    // gives confirmTid live coverage.
+    Client sap = check getTestClient();
+    string tid = check sap->createTid();
+    string first = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"TCPICDAT": tcpicRows("TRFC-RETRY")},
+            tid, autoConfirm = false);
+    string second = check sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"TCPICDAT": tcpicRows("TRFC-RETRY")},
+            tid, autoConfirm = false);
+    test:assertEquals(first, tid);
+    test:assertEquals(second, tid);
+    check sap->confirmTid(tid);
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendQRfc() returns error? {
+    Client sap = check getTestClient();
+    string tid = check sap->sendQRfc("STFC_WRITE_TO_TCPIC", queueName, {"TCPICDAT": tcpicRows("QRFC")});
+    test:assertTrue(tid.length() > 0, "expected a non-empty TID");
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendQRfcSequence() returns error? {
+    // Both sends to the same queue must be accepted; in-order processing on the backend
+    // is verified at data level by the external verifier (row order of -QRFC-ORD-1/-2).
+    Client sap = check getTestClient();
+    string tid1 = check sap->sendQRfc("STFC_WRITE_TO_TCPIC", queueName, {"TCPICDAT": tcpicRows("QRFC-ORD-1")});
+    string tid2 = check sap->sendQRfc("STFC_WRITE_TO_TCPIC", queueName, {"TCPICDAT": tcpicRows("QRFC-ORD-2")});
+    test:assertNotEquals(tid1, tid2, "each qRFC call must get its own TID");
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendQRfcEmptyQueueName() returns error? {
+    Client sap = check getTestClient();
+    string|Error result = sap->sendQRfc("STFC_WRITE_TO_TCPIC", "", {"TCPICDAT": tcpicRows("QRFC-EMPTY")});
+    test:assertTrue(result is Error, "an empty queue name must be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("Queue name"), result.message());
+    }
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendBgRfcUnitTypeT() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo unit = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("BGRFC-T-1")}},
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("BGRFC-T-2")}}
+    ], {unitHistory: true});
+    test:assertEquals(unit.unitType, BGRFC_TYPE_T, "a unit without queue names must be type T");
+    test:assertEquals(unit.unitId.length(), 32, "expected a 32-character hexadecimal unit ID");
+
+    BgRfcUnitState state = check waitForUnitProcessing(sap, unit);
+    test:assertTrue(state is COMMITTED|CONFIRMED|IN_PROCESS,
+            string `expected the unit to be accepted by the backend, got state '${state}'`);
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendBgRfcUnitTypeQ() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo unit = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("BGRFC-Q")}}
+    ], {queueNames: [queueName], unitHistory: true});
+    test:assertEquals(unit.unitType, BGRFC_TYPE_Q, "a unit with queue names must be type Q");
+
+    BgRfcUnitState state = check waitForUnitProcessing(sap, unit);
+    test:assertTrue(state is COMMITTED|CONFIRMED|IN_PROCESS,
+            string `expected the unit to be accepted by the backend, got state '${state}'`);
+}
+
+@test:Config {enable: enableLiveTests}
+function testConfirmBgRfcUnit() returns error? {
+    Client sap = check getTestClient();
+    BgRfcUnitInfo unit = check sap->sendBgRfcUnit([
+        {functionName: "STFC_WRITE_TO_TCPIC", importParams: {"TCPICDAT": tcpicRows("BGRFC-CONF")}}
+    ], {unitHistory: true});
+    BgRfcUnitState processed = check waitForUnitProcessing(sap, unit);
+    test:assertEquals(processed, COMMITTED,
+            "the unit must reach COMMITTED (processing finished) before confirmation");
+    check sap->confirmBgRfcUnit(unit);
+    BgRfcUnitState confirmed = check sap->getBgRfcUnitState(unit);
+    // Without unit history the backend may already have deleted the status record.
+    test:assertTrue(confirmed is CONFIRMED|NOT_FOUND,
+            string `expected CONFIRMED (or cleaned up) after confirmation, got '${confirmed}'`);
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendTRfcUnknownFunction() returns error? {
+    Client sap = check getTestClient();
+    string|Error result = sap->sendTRfc("BALLERINA_NO_SUCH_FUNCTION");
+    test:assertTrue(result is Error, "sending an unknown function must fail");
+    if result is Error {
+        test:assertTrue(result.message().includes("not found"), result.message());
+    }
+}
+
+@test:Config {enable: enableLiveTests}
+function testSendTRfcUnknownParameter() returns error? {
+    Client sap = check getTestClient();
+    string|Error result = sap->sendTRfc("STFC_WRITE_TO_TCPIC", {"BOGUS_PARAM": "x"});
+    test:assertTrue(result is Error, "sending an undefined parameter must fail");
+    if result is Error {
+        test:assertTrue(result.message().includes("BOGUS_PARAM"), result.message());
+    }
+}
+
+// Polls until the unit leaves the in-flight states. COMMITTED is the terminal state from the
+// sender's perspective until confirmBgRfcUnit is called (CONFIRMED only exists after that).
+isolated function waitForUnitProcessing(Client sap, BgRfcUnitInfo unit) returns BgRfcUnitState|error {
+    BgRfcUnitState state = NOT_FOUND;
+    foreach int attempt in 0 ..< 10 {
+        state = check sap->getBgRfcUnitState(unit);
+        if state is COMMITTED|CONFIRMED|ROLLED_BACK {
+            break;
+        }
+        runtime:sleep(1);
+    }
+    return state;
+}

--- a/ballerina/tests/transaction_tests.bal
+++ b/ballerina/tests/transaction_tests.bal
@@ -79,8 +79,11 @@ function testMultipleClients() returns error? {
     // "DestinationDataProvider already registered".
     Client first = check getTestClient();
     Client second = check new ({host, systemNumber, jcoClient, user, password});
-    string tid = check second->createTid();
-    test:assertTrue(tid.length() > 0);
+    string firstTid = check first->createTid();
+    string secondTid = check second->createTid();
+    test:assertTrue(firstTid.length() > 0, "the first client must stay usable");
+    test:assertTrue(secondTid.length() > 0, "the second client must be usable");
+    test:assertNotEquals(firstTid, secondTid, "each client must get its own TID");
 }
 
 @test:Config {enable: enableLiveTests}

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -228,4 +228,82 @@ public enum IDocType {
 
 public type FieldType string|int|float|decimal|time:Date|byte[];
 
+# Represents a structure parameter of an RFC function: a record whose fields are scalar
+# values, nested structures, or tables (arrays of structures).
+public type ParamStructure record {|ParamValue?...;|};
+
+# Represents a value assignable to an RFC parameter: a scalar field, a structure, or a table.
+public type ParamValue FieldType|ParamStructure|ParamStructure[];
+
+# Represents a single function invocation inside a bgRFC unit.
+#
+# + functionName - The name of the RFC-enabled function module to invoke.
+# + importParams - The import, changing, and table parameters for the invocation.
+public type FunctionCall record {|
+    string functionName;
+    ParamStructure importParams = {};
+|};
+
+# The type of a bgRFC unit: `T` (transactional, exactly-once) or
+# `Q` (queued, exactly-once-in-order).
+public enum BgRfcUnitType {
+    BGRFC_TYPE_T = "T",
+    BGRFC_TYPE_Q = "Q"
+}
+
+# The processing state of a bgRFC unit as reported by the SAP backend.
+public enum BgRfcUnitState {
+    NOT_FOUND,
+    IN_PROCESS,
+    COMMITTED,
+    CONFIRMED,
+    ROLLED_BACK
+}
+
+# Configurations for a bgRFC unit.
+#
+# + unitId - A 32-character hexadecimal unit ID to use. If not given, a unique ID is generated.
+# + queueNames - The inbound queues the unit is assigned to. If one or more queue names are
+#                given, the unit becomes a type Q (bg-qRFC) unit; otherwise it is type T.
+# + 'lock - Locks the unit in the backend so that it is held back from processing until unlocked.
+# + unitHistory - Records the unit history in the backend.
+# + kernelTrace - Enables kernel tracing for the unit.
+# + commitCheck - Checks whether the unit can be processed before committing.
+# + programName - The calling program name to record with the unit.
+# + transactionCode - The transaction code to record with the unit.
+public type BgRfcUnitConfig record {|
+    string unitId?;
+    string[] queueNames = [];
+    boolean 'lock = false;
+    boolean unitHistory = false;
+    boolean kernelTrace = false;
+    boolean commitCheck = false;
+    string programName?;
+    string transactionCode?;
+|};
+
+# Identifies a committed bgRFC unit.
+#
+# + unitId - The 32-character hexadecimal ID of the unit.
+# + unitType - The type of the unit (T or Q).
+public type BgRfcUnitInfo record {|
+    string unitId;
+    BgRfcUnitType unitType;
+|};
+
 public type Error distinct error;
+
+# The detail record of a `TransactionError`.
+#
+# + tid - The transaction ID of the failed operation. Set by `sendTRfc`, `sendQRfc`, and
+#         `confirmTid` failures when a TID was already created. Retrying the send with this
+#         TID preserves exactly-once semantics.
+# + unitId - The bgRFC unit ID of the failed operation. Set by `sendBgRfcUnit`,
+#            `getBgRfcUnitState`, and `confirmBgRfcUnit` failures.
+public type TransactionErrorDetail record {
+    string tid?;
+    string unitId?;
+};
+
+# Represents an error that occurred while sending a transactional (tRFC/qRFC/bgRFC) call.
+public type TransactionError distinct Error & error<TransactionErrorDetail>;

--- a/native/src/main/java/io/ballerina/lib/sap/BallerinaDestinationDataProvider.java
+++ b/native/src/main/java/io/ballerina/lib/sap/BallerinaDestinationDataProvider.java
@@ -20,16 +20,37 @@ package io.ballerina.lib.sap;
 
 import com.sap.conn.jco.ext.DestinationDataEventListener;
 import com.sap.conn.jco.ext.DestinationDataProvider;
+import com.sap.conn.jco.ext.Environment;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class BallerinaDestinationDataProvider implements DestinationDataProvider {
 
-    private final Map<String, Properties> destinationProperties = new HashMap<>();
+    // JCo allows exactly one DestinationDataProvider per JVM, so all clients and listeners
+    // share this instance; each adds its own destination to the map.
+    private static final BallerinaDestinationDataProvider INSTANCE = new BallerinaDestinationDataProvider();
+    private static boolean registered = false;
+
+    private final Map<String, Properties> destinationProperties = new ConcurrentHashMap<>();
+
+    private BallerinaDestinationDataProvider() {
+    }
+
+    public static synchronized BallerinaDestinationDataProvider getRegisteredInstance() {
+        if (!registered) {
+            if (Environment.isDestinationDataProviderRegistered()) {
+                throw new IllegalStateException("A different JCo DestinationDataProvider is already " +
+                        "registered in this JVM. The Ballerina SAP connector cannot manage destinations.");
+            }
+            Environment.registerDestinationDataProvider(INSTANCE);
+            registered = true;
+        }
+        return INSTANCE;
+    }
 
     @Override
     public Properties getDestinationProperties(String destinationName) {

--- a/native/src/main/java/io/ballerina/lib/sap/Client.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Client.java
@@ -58,8 +58,7 @@ public class Client {
     public static Object initializeClient(BObject client, BMap<BString, Object> jcoDestinationConfig,
                                           BString destinationId, boolean setImportParamNull) {
         try {
-            BallerinaDestinationDataProvider dp = new BallerinaDestinationDataProvider();
-            com.sap.conn.jco.ext.Environment.registerDestinationDataProvider(dp);
+            BallerinaDestinationDataProvider dp = BallerinaDestinationDataProvider.getRegisteredInstance();
             dp.addDestination(jcoDestinationConfig, destinationId);
             JCoDestination destination = JCoDestinationManager.getDestination(destinationId.toString());
             destination.ping();

--- a/native/src/main/java/io/ballerina/lib/sap/Listener.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Listener.java
@@ -45,8 +45,7 @@ public class Listener {
     public static Object init(BObject listenerBObject, BMap<BString, Object> jcoDestinationConfig,
                               BString destinationId) {
         try {
-            BallerinaDestinationDataProvider dp = new BallerinaDestinationDataProvider();
-            com.sap.conn.jco.ext.Environment.registerDestinationDataProvider(dp);
+            BallerinaDestinationDataProvider dp = BallerinaDestinationDataProvider.getRegisteredInstance();
             dp.addDestination(jcoDestinationConfig, destinationId);
             JCoDestination destination = JCoDestinationManager.getDestination(destinationId.toString());
             JCoIDocServer server = JCoIDoc.getServer(destination.getDestinationName());

--- a/native/src/main/java/io/ballerina/lib/sap/ParameterProcessor.java
+++ b/native/src/main/java/io/ballerina/lib/sap/ParameterProcessor.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.lib.sap;
+
+import com.sap.conn.jco.JCoFunction;
+import com.sap.conn.jco.JCoParameterList;
+import com.sap.conn.jco.JCoRecord;
+import com.sap.conn.jco.JCoTable;
+import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.utils.TypeUtils;
+import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
+
+import java.math.BigDecimal;
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Populates JCo parameter lists (import, changing and table parameters) from Ballerina values.
+ * Supports scalar fields, nested structures, tables (arrays of records) and {@code time:Date} records.
+ */
+public final class ParameterProcessor {
+
+    private ParameterProcessor() {
+    }
+
+    /**
+     * Sets the given Ballerina parameter map onto the function, routing each entry to the
+     * import, changing or table parameter list it belongs to.
+     */
+    public static void setParameters(JCoFunction function, BMap<BString, Object> params, boolean setNullValues) {
+        JCoParameterList[] lists = {function.getImportParameterList(), function.getChangingParameterList(),
+                function.getTableParameterList()};
+        params.entrySet().forEach(entry -> {
+            String name = entry.getKey().toString();
+            JCoParameterList target = null;
+            for (JCoParameterList list : lists) {
+                if (list != null && list.getListMetaData().hasField(name)) {
+                    target = list;
+                    break;
+                }
+            }
+            if (target == null) {
+                throw SAPErrorCreator.fromBError("Parameter '" + name + "' is not defined as an import, changing " +
+                        "or table parameter of function '" + function.getName() + "'.", null);
+            }
+            Object value = entry.getValue();
+            if (value == null) {
+                if (setNullValues) {
+                    target.setValue(name, (Object) null);
+                }
+                return;
+            }
+            setField(target, name, value);
+        });
+    }
+
+    private static void setField(JCoRecord record, String name, Object value) {
+        int tag = resolveTypeTag(value);
+        switch (tag) {
+            case TypeTags.STRING_TAG:
+                record.setValue(name, value.toString());
+                break;
+            case TypeTags.INT_TAG:
+            case TypeTags.BYTE_TAG:
+                record.setValue(name, Long.parseLong(value.toString()));
+                break;
+            case TypeTags.FLOAT_TAG:
+                record.setValue(name, Double.parseDouble(value.toString()));
+                break;
+            case TypeTags.DECIMAL_TAG:
+                record.setValue(name, new BigDecimal(value.toString()));
+                break;
+            case TypeTags.BYTE_ARRAY_TAG:
+            case TypeTags.ARRAY_TAG:
+            case TypeTags.TUPLE_TAG:
+                setArrayField(record, name, (BArray) value);
+                break;
+            case TypeTags.RECORD_TYPE_TAG:
+            case TypeTags.MAP_TAG:
+                setMappingField(record, name, value);
+                break;
+            default:
+                throw SAPErrorCreator.fromBError("Unsupported value for parameter '" + name + "'. Supported " +
+                        "types are: string, int, float, decimal, byte[], records (structures), arrays of " +
+                        "records (tables) and time:Date.", null);
+        }
+    }
+
+    private static void setArrayField(JCoRecord record, String name, BArray array) {
+        // Byte-array detection goes through the type (tuples have no uniform element type).
+        Type type = TypeUtils.getImpliedType(TypeUtils.getType(array));
+        if (type.getTag() == TypeTags.ARRAY_TAG
+                && TypeUtils.getImpliedType(((ArrayType) type).getElementType()).getTag() == TypeTags.BYTE_TAG) {
+            record.setValue(name, array.getBytes());
+            return;
+        }
+        JCoTable table = record.getTable(name);
+        populateTable(table, array, name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void setMappingField(JCoRecord record, String name, Object value) {
+        BMap<BString, Object> mapping = (BMap<BString, Object>) value;
+        if (isDateRecord(value)) {
+            record.setValue(name, extractDate(mapping, name));
+        } else {
+            populateRecord(record.getStructure(name), mapping);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void populateTable(JCoTable table, BArray rows, String name) {
+        for (int i = 0; i < rows.size(); i++) {
+            Object row = rows.get(i);
+            if (row == null) {
+                throw SAPErrorCreator.fromBError("Row " + i + " of table parameter '" + name +
+                        "' is nil. Table rows must be non-nil.", null);
+            }
+            table.appendRow();
+            if (row instanceof BMap) {
+                populateRecord(table, (BMap<BString, Object>) row);
+            } else {
+                // Unstructured line type (single unnamed column), e.g. a table of CHAR lines.
+                setScalarByIndex(table, row, name);
+            }
+        }
+    }
+
+    private static void setScalarByIndex(JCoTable table, Object value, String name) {
+        int tag = resolveTypeTag(value);
+        switch (tag) {
+            case TypeTags.STRING_TAG:
+                table.setValue(0, value.toString());
+                break;
+            case TypeTags.INT_TAG:
+            case TypeTags.BYTE_TAG:
+                table.setValue(0, Long.parseLong(value.toString()));
+                break;
+            case TypeTags.FLOAT_TAG:
+                table.setValue(0, Double.parseDouble(value.toString()));
+                break;
+            case TypeTags.DECIMAL_TAG:
+                table.setValue(0, new BigDecimal(value.toString()));
+                break;
+            default:
+                throw SAPErrorCreator.fromBError("Unsupported row value in table parameter '" + name +
+                        "'. Rows of unstructured tables must be string, int, float or decimal values.", null);
+        }
+    }
+
+    private static void populateRecord(JCoRecord jcoRecord, BMap<BString, Object> mapping) {
+        mapping.entrySet().forEach(entry -> {
+            String fieldName = entry.getKey().toString();
+            Object value = entry.getValue();
+            if (value == null) {
+                return;
+            }
+            setField(jcoRecord, fieldName, value);
+        });
+    }
+
+    private static boolean isDateRecord(Object value) {
+        Type type = TypeUtils.getImpliedType(TypeUtils.getType(value));
+        if (SAPConstants.DATE.equals(type.getName())) {
+            return true;
+        }
+        // Readonly/cloned time:Date values can lose the type name; fall back to shape. SAP
+        // structure fields are uppercase, so lowercase year/month/day cannot collide with them.
+        if (value instanceof BMap) {
+            BMap<?, ?> mapping = (BMap<?, ?>) value;
+            return mapping.containsKey(StringUtils.fromString("year"))
+                    && mapping.containsKey(StringUtils.fromString("month"))
+                    && mapping.containsKey(StringUtils.fromString("day"));
+        }
+        return false;
+    }
+
+    private static Date extractDate(BMap<BString, Object> dateMap, String name) {
+        Object yearObj = dateMap.get(StringUtils.fromString("year"));
+        Object monthObj = dateMap.get(StringUtils.fromString("month"));
+        Object dayObj = dateMap.get(StringUtils.fromString("day"));
+        Object hourObj = dateMap.get(StringUtils.fromString("hour"));
+        Object minuteObj = dateMap.get(StringUtils.fromString("minute"));
+        Object secondObj = dateMap.get(StringUtils.fromString("second"));
+
+        if (yearObj == null || monthObj == null || dayObj == null) {
+            throw SAPErrorCreator.fromBError("Invalid date value for parameter '" + name + "': year, month, and " +
+                    "day must be provided.", null);
+        }
+        int year = Integer.parseInt(yearObj.toString());
+        int month = Integer.parseInt(monthObj.toString());
+        int day = Integer.parseInt(dayObj.toString());
+        int hour = (hourObj != null) ? Integer.parseInt(hourObj.toString()) : 0;
+        int minute = (minuteObj != null) ? Integer.parseInt(minuteObj.toString()) : 0;
+        // time:Date seconds are decimal; truncate fractions for the DATE/TIME conversion.
+        int second = (secondObj != null) ? new BigDecimal(secondObj.toString()).intValue() : 0;
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear();
+        calendar.set(year, month - 1, day, hour, minute, second);
+        return calendar.getTime();
+    }
+
+    private static int resolveTypeTag(Object value) {
+        Type type = TypeUtils.getImpliedType(TypeUtils.getType(value));
+        int tag = type.getTag();
+        if (tag == TypeTags.UNION_TAG) {
+            UnionType unionType = (UnionType) type;
+            if (unionType.getMemberTypes().size() == 2) {
+                int first = unionType.getMemberTypes().get(0).getTag();
+                int second = unionType.getMemberTypes().get(1).getTag();
+                if (first == TypeTags.NULL_TAG) {
+                    return second;
+                }
+                if (second == TypeTags.NULL_TAG) {
+                    return first;
+                }
+            }
+            throw SAPErrorCreator.fromBError("Unsupported union type '" + type.getName() + "'. Only nullable " +
+                    "variants of the supported types are allowed.", null);
+        }
+        return tag;
+    }
+}

--- a/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
@@ -52,6 +52,8 @@ public class SAPConstants {
     public static final String TRANSACTION_ERROR = "TransactionError";
     public static final String TRANSACTION_ERROR_DETAIL = "TransactionErrorDetail";
     public static final String TID_FIELD = "tid";
+    public static final int TID_LENGTH = 24;
+    public static final int UNIT_ID_LENGTH = 32;
 
     // Constants for SAP Destination Provider Configurations
     public static final Map<String, String> CONFIG_KEYS = Map.<String, String>ofEntries(

--- a/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
@@ -33,6 +33,26 @@ public class SAPConstants {
     public static final String SET_NULL = "setImportParamNull";
     public static final String DATE = "Date";
 
+    // Constants for transactional RFC support (tRFC, qRFC, bgRFC)
+    public static final String T = "T";
+    public static final String Q = "Q";
+    public static final String UNIT_ID = "unitId";
+    public static final String QUEUE_NAMES = "queueNames";
+    public static final String FUNCTION_NAME = "functionName";
+    public static final String IMPORT_PARAMS = "importParams";
+    public static final String LOCK = "lock";
+    public static final String UNIT_HISTORY = "unitHistory";
+    public static final String KERNEL_TRACE = "kernelTrace";
+    public static final String COMMIT_CHECK = "commitCheck";
+    public static final String PROGRAM_NAME = "programName";
+    public static final String TRANSACTION_CODE = "transactionCode";
+    public static final String BGRFC_UNIT_INFO_RECORD = "BgRfcUnitInfo";
+    public static final String UNIT_ID_FIELD = "unitId";
+    public static final String UNIT_TYPE_FIELD = "unitType";
+    public static final String TRANSACTION_ERROR = "TransactionError";
+    public static final String TRANSACTION_ERROR_DETAIL = "TransactionErrorDetail";
+    public static final String TID_FIELD = "tid";
+
     // Constants for SAP Destination Provider Configurations
     public static final Map<String, String> CONFIG_KEYS = Map.<String, String>ofEntries(
             Map.entry("jcoClient", DestinationDataProvider.JCO_CLIENT),

--- a/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
@@ -20,8 +20,11 @@ package io.ballerina.lib.sap;
 
 import com.sap.conn.idoc.IDocException;
 import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BString;
 public class SAPErrorCreator {
     public static BError fromJCoException(Throwable e) {
         return fromJavaException("JCo Error: " + e.getMessage(), e);
@@ -41,5 +44,23 @@ public class SAPErrorCreator {
         BError cause = ErrorCreator.createError(throwable);
         return ErrorCreator.createError(
                 ModuleUtils.getModule(), "Error", StringUtils.fromString(message), cause, null);
+    }
+
+    /**
+     * Creates a {@code sap.jco:TransactionError} carrying the TID or bgRFC unit ID of the failed
+     * transaction, so callers can retry with the same identifier and keep exactly-once semantics.
+     */
+    public static BError transactionError(String message, Throwable cause, String tid, String unitId) {
+        BMap<BString, Object> detail = ValueCreator.createRecordValue(
+                ModuleUtils.getModule(), SAPConstants.TRANSACTION_ERROR_DETAIL);
+        if (tid != null) {
+            detail.put(StringUtils.fromString(SAPConstants.TID_FIELD), StringUtils.fromString(tid));
+        }
+        if (unitId != null) {
+            detail.put(StringUtils.fromString(SAPConstants.UNIT_ID), StringUtils.fromString(unitId));
+        }
+        BError bCause = cause == null ? null : ErrorCreator.createError(cause);
+        return ErrorCreator.createError(ModuleUtils.getModule(), SAPConstants.TRANSACTION_ERROR,
+                StringUtils.fromString(message), bCause, detail);
     }
 }

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -89,17 +89,15 @@ public final class Transactions {
                                             boolean autoConfirm) {
         String tidStr = null;
         try {
+            if (tid != null) {
+                validateTid(tid.toString());
+            }
             JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
             JCoFunction function = lookupFunction(destination, functionName);
             boolean setNull = (boolean) client.getNativeData(SAPConstants.SET_NULL);
             ParameterProcessor.setParameters(function, importParams, setNull);
 
-            if (tid == null) {
-                tidStr = destination.createTID();
-            } else {
-                validateTid(tid.toString());
-                tidStr = tid.toString();
-            }
+            tidStr = tid == null ? destination.createTID() : tid.toString();
             if (queueName == null) {
                 function.execute(destination, tidStr);
             } else {
@@ -226,15 +224,23 @@ public final class Transactions {
         }
     }
 
-    // JCo parses these identifiers positionally and throws raw StringIndexOutOfBoundsException
-    // on a malformed value, so they are checked here to fail with an actionable message instead.
+    // A TID is split positionally by JCo into four fixed-width character fields, so anything
+    // shorter than 24 characters raises a raw StringIndexOutOfBoundsException, and anything
+    // longer is silently truncated - which would break exactly-once, because SAP would then
+    // record a different identifier than the caller believes it used. The content itself is
+    // not restricted: SAP stores the TID components as CHAR, so an application is free to
+    // derive a TID from its own idempotency key.
     private static void validateTid(String tid) {
-        if (!isHexOfLength(tid, SAPConstants.TID_LENGTH)) {
-            throw SAPErrorCreator.fromBError("Invalid transaction ID '" + tid + "'. A TID must be a " +
-                    SAPConstants.TID_LENGTH + "-character hexadecimal string, as returned by createTid().", null);
+        if (tid == null || tid.length() != SAPConstants.TID_LENGTH) {
+            throw SAPErrorCreator.fromBError("Invalid transaction ID '" + tid + "'. A TID must be exactly " +
+                    SAPConstants.TID_LENGTH + " characters long, as returned by createTid().", null);
         }
     }
 
+    // Unit IDs, unlike TIDs, are genuinely 16 bytes in hexadecimal - JCo documents that and
+    // rejects bad values in createUnitIdentifier. JCo.createFunctionUnit however accepts any
+    // length without complaint, so a wrong ID would only surface later when the unit is
+    // queried; validating here keeps that failure at the call that caused it.
     private static void validateUnitId(String unitId) {
         if (!isHexOfLength(unitId, SAPConstants.UNIT_ID_LENGTH)) {
             throw SAPErrorCreator.fromBError("Invalid bgRFC unit ID '" + unitId + "'. A unit ID must be a " +
@@ -247,7 +253,9 @@ public final class Transactions {
             return false;
         }
         for (int i = 0; i < length; i++) {
-            if (Character.digit(value.charAt(i), 16) == -1) {
+            char c = value.charAt(i);
+            boolean hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!hex) {
                 return false;
             }
         }

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -58,9 +58,12 @@ public final class Transactions {
 
     public static Object confirmTid(BObject client, BString tid) {
         try {
+            validateTid(tid.toString());
             JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
             destination.confirmTID(tid.toString());
             return null;
+        } catch (BError e) {
+            return e;
         } catch (JCoException e) {
             return SAPErrorCreator.transactionError("Failed to confirm TID '" + tid + "': " + e.getMessage(),
                     e, tid.toString(), null);
@@ -91,7 +94,12 @@ public final class Transactions {
             boolean setNull = (boolean) client.getNativeData(SAPConstants.SET_NULL);
             ParameterProcessor.setParameters(function, importParams, setNull);
 
-            tidStr = tid == null ? destination.createTID() : tid.toString();
+            if (tid == null) {
+                tidStr = destination.createTID();
+            } else {
+                validateTid(tid.toString());
+                tidStr = tid.toString();
+            }
             if (queueName == null) {
                 function.execute(destination, tidStr);
             } else {
@@ -135,6 +143,9 @@ public final class Transactions {
 
             JCoBackgroundUnitAttributes attributes = buildAttributes(unitConfig);
             Object configuredId = unitConfig.get(StringUtils.fromString(SAPConstants.UNIT_ID));
+            if (configuredId != null) {
+                validateUnitId(configuredId.toString());
+            }
             JCoFunctionUnit unit = configuredId == null ? JCo.createFunctionUnit(attributes)
                     : JCo.createFunctionUnit(configuredId.toString(), attributes);
 
@@ -181,6 +192,7 @@ public final class Transactions {
     public static Object getBgRfcUnitState(BObject client, BMap<BString, Object> unitInfo) {
         String unitId = unitField(unitInfo, SAPConstants.UNIT_ID_FIELD);
         try {
+            validateUnitId(unitId);
             JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
             JCoUnitIdentifier identifier = JCo.createUnitIdentifier(unitId,
                     toUnitType(unitField(unitInfo, SAPConstants.UNIT_TYPE_FIELD)));
@@ -188,6 +200,8 @@ public final class Transactions {
         } catch (JCoException e) {
             return SAPErrorCreator.transactionError("Failed to get bgRFC unit state for unit '" + unitId +
                     "': " + e.getMessage(), e, null, unitId);
+        } catch (BError e) {
+            return e;
         } catch (Exception e) {
             return SAPErrorCreator.createError("Failed to get bgRFC unit state.", e);
         }
@@ -196,6 +210,7 @@ public final class Transactions {
     public static Object confirmBgRfcUnit(BObject client, BMap<BString, Object> unitInfo) {
         String unitId = unitField(unitInfo, SAPConstants.UNIT_ID_FIELD);
         try {
+            validateUnitId(unitId);
             JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
             JCoUnitIdentifier identifier = JCo.createUnitIdentifier(unitId,
                     toUnitType(unitField(unitInfo, SAPConstants.UNIT_TYPE_FIELD)));
@@ -204,9 +219,39 @@ public final class Transactions {
         } catch (JCoException e) {
             return SAPErrorCreator.transactionError("Failed to confirm bgRFC unit '" + unitId + "': " +
                     e.getMessage(), e, null, unitId);
+        } catch (BError e) {
+            return e;
         } catch (Exception e) {
             return SAPErrorCreator.createError("Failed to confirm bgRFC unit.", e);
         }
+    }
+
+    // JCo parses these identifiers positionally and throws raw StringIndexOutOfBoundsException
+    // on a malformed value, so they are checked here to fail with an actionable message instead.
+    private static void validateTid(String tid) {
+        if (!isHexOfLength(tid, SAPConstants.TID_LENGTH)) {
+            throw SAPErrorCreator.fromBError("Invalid transaction ID '" + tid + "'. A TID must be a " +
+                    SAPConstants.TID_LENGTH + "-character hexadecimal string, as returned by createTid().", null);
+        }
+    }
+
+    private static void validateUnitId(String unitId) {
+        if (!isHexOfLength(unitId, SAPConstants.UNIT_ID_LENGTH)) {
+            throw SAPErrorCreator.fromBError("Invalid bgRFC unit ID '" + unitId + "'. A unit ID must be a " +
+                    SAPConstants.UNIT_ID_LENGTH + "-character hexadecimal string.", null);
+        }
+    }
+
+    private static boolean isHexOfLength(String value, int length) {
+        if (value == null || value.length() != length) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            if (Character.digit(value.charAt(i), 16) == -1) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private static String unitField(BMap<BString, Object> unitInfo, String field) {

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.lib.sap;
+
+import com.sap.conn.jco.JCo;
+import com.sap.conn.jco.JCoBackgroundUnitAttributes;
+import com.sap.conn.jco.JCoDestination;
+import com.sap.conn.jco.JCoException;
+import com.sap.conn.jco.JCoFunction;
+import com.sap.conn.jco.JCoFunctionUnit;
+import com.sap.conn.jco.JCoRepository;
+import com.sap.conn.jco.JCoUnitIdentifier;
+import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implements transactional RFC protocols on top of JCo: tRFC (exactly-once), qRFC (exactly-once
+ * in order) and bgRFC units of type T and Q.
+ */
+public final class Transactions {
+
+    private static final Logger logger = LoggerFactory.getLogger(Transactions.class);
+
+    private Transactions() {
+    }
+
+    public static Object createTid(BObject client) {
+        try {
+            JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+            return StringUtils.fromString(destination.createTID());
+        } catch (JCoException e) {
+            return SAPErrorCreator.fromJCoException(e);
+        }
+    }
+
+    public static Object confirmTid(BObject client, BString tid) {
+        try {
+            JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+            destination.confirmTID(tid.toString());
+            return null;
+        } catch (JCoException e) {
+            return SAPErrorCreator.transactionError("Failed to confirm TID '" + tid + "': " + e.getMessage(),
+                    e, tid.toString(), null);
+        }
+    }
+
+    public static Object sendTRfc(BObject client, BString functionName, BMap<BString, Object> importParams,
+                                  Object tid, boolean autoConfirm) {
+        return sendTransactional(client, functionName, importParams, tid, null, autoConfirm);
+    }
+
+    public static Object sendQRfc(BObject client, BString functionName, BString queueName,
+                                  BMap<BString, Object> importParams, Object tid, boolean autoConfirm) {
+        String queue = queueName.toString();
+        if (queue.isEmpty()) {
+            return SAPErrorCreator.fromBError("Queue name is empty.", null);
+        }
+        return sendTransactional(client, functionName, importParams, tid, queue, autoConfirm);
+    }
+
+    private static Object sendTransactional(BObject client, BString functionName,
+                                            BMap<BString, Object> importParams, Object tid, String queueName,
+                                            boolean autoConfirm) {
+        String tidStr = null;
+        try {
+            JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+            JCoFunction function = lookupFunction(destination, functionName);
+            boolean setNull = (boolean) client.getNativeData(SAPConstants.SET_NULL);
+            ParameterProcessor.setParameters(function, importParams, setNull);
+
+            tidStr = tid == null ? destination.createTID() : tid.toString();
+            if (queueName == null) {
+                function.execute(destination, tidStr);
+            } else {
+                function.execute(destination, tidStr, queueName);
+            }
+            if (autoConfirm) {
+                confirmQuietly(destination, tidStr);
+            }
+            return StringUtils.fromString(tidStr);
+        } catch (JCoException e) {
+            String protocol = queueName == null ? "tRFC" : "qRFC";
+            return SAPErrorCreator.transactionError(protocol + " execution failed for function '" + functionName +
+                    "': " + e.getMessage(), e, tidStr, null);
+        } catch (BError e) {
+            return e;
+        } catch (Exception e) {
+            return SAPErrorCreator.createError("Failed to send transactional function call.", e);
+        }
+    }
+
+    // A failure to confirm does not undo the delivery: the LUW is already recorded in SAP and
+    // retrying the same TID would not create duplicates. Hence this is logged, not surfaced.
+    private static void confirmQuietly(JCoDestination destination, String tid) {
+        try {
+            destination.confirmTID(tid);
+        } catch (JCoException e) {
+            logger.warn("Function call was delivered, but confirming TID {} failed. SAP will clean up the "
+                    + "TID record eventually. Cause: {}", tid, e.getMessage());
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Object sendBgRfcUnit(BObject client, BArray functionCalls, BMap<BString, Object> unitConfig) {
+        String unitIdStr = null;
+        try {
+            JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+            boolean setNull = (boolean) client.getNativeData(SAPConstants.SET_NULL);
+            if (functionCalls.size() == 0) {
+                return SAPErrorCreator.fromBError("A bgRFC unit must contain at least one function call.", null);
+            }
+
+            JCoBackgroundUnitAttributes attributes = buildAttributes(unitConfig);
+            Object configuredId = unitConfig.get(StringUtils.fromString(SAPConstants.UNIT_ID));
+            JCoFunctionUnit unit = configuredId == null ? JCo.createFunctionUnit(attributes)
+                    : JCo.createFunctionUnit(configuredId.toString(), attributes);
+
+            BArray queueNames = (BArray) unitConfig.get(StringUtils.fromString(SAPConstants.QUEUE_NAMES));
+            if (queueNames != null) {
+                for (int i = 0; i < queueNames.size(); i++) {
+                    unit.addQueueName(queueNames.getBString(i).toString());
+                }
+            }
+
+            for (int i = 0; i < functionCalls.size(); i++) {
+                BMap<BString, Object> call = (BMap<BString, Object>) functionCalls.get(i);
+                BString name = (BString) call.get(StringUtils.fromString(SAPConstants.FUNCTION_NAME));
+                BMap<BString, Object> params =
+                        (BMap<BString, Object>) call.get(StringUtils.fromString(SAPConstants.IMPORT_PARAMS));
+                JCoFunction function = lookupFunction(destination, name);
+                if (params != null) {
+                    ParameterProcessor.setParameters(function, params, setNull);
+                }
+                unit.addFunction(function);
+            }
+
+            JCoUnitIdentifier identifier = unit.getIdentifier();
+            unitIdStr = identifier.getID();
+            unit.commit(destination);
+
+            BMap<BString, Object> unitInfo = ValueCreator.createRecordValue(ModuleUtils.getModule(),
+                    SAPConstants.BGRFC_UNIT_INFO_RECORD);
+            unitInfo.put(StringUtils.fromString(SAPConstants.UNIT_ID_FIELD), StringUtils.fromString(unitIdStr));
+            unitInfo.put(StringUtils.fromString(SAPConstants.UNIT_TYPE_FIELD),
+                    StringUtils.fromString(identifier.getType() == JCoUnitIdentifier.Type.TYPE_Q
+                            ? SAPConstants.Q : SAPConstants.T));
+            return unitInfo;
+        } catch (JCoException e) {
+            return SAPErrorCreator.transactionError("bgRFC unit commit failed: " + e.getMessage(), e,
+                    null, unitIdStr);
+        } catch (BError e) {
+            return e;
+        } catch (Exception e) {
+            return SAPErrorCreator.createError("Failed to send bgRFC unit.", e);
+        }
+    }
+
+    public static Object getBgRfcUnitState(BObject client, BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.UNIT_ID_FIELD);
+        try {
+            JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+            JCoUnitIdentifier identifier = JCo.createUnitIdentifier(unitId,
+                    toUnitType(unitField(unitInfo, SAPConstants.UNIT_TYPE_FIELD)));
+            return StringUtils.fromString(destination.getFunctionUnitState(identifier).name());
+        } catch (JCoException e) {
+            return SAPErrorCreator.transactionError("Failed to get bgRFC unit state for unit '" + unitId +
+                    "': " + e.getMessage(), e, null, unitId);
+        } catch (Exception e) {
+            return SAPErrorCreator.createError("Failed to get bgRFC unit state.", e);
+        }
+    }
+
+    public static Object confirmBgRfcUnit(BObject client, BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.UNIT_ID_FIELD);
+        try {
+            JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+            JCoUnitIdentifier identifier = JCo.createUnitIdentifier(unitId,
+                    toUnitType(unitField(unitInfo, SAPConstants.UNIT_TYPE_FIELD)));
+            destination.confirmFunctionUnit(identifier);
+            return null;
+        } catch (JCoException e) {
+            return SAPErrorCreator.transactionError("Failed to confirm bgRFC unit '" + unitId + "': " +
+                    e.getMessage(), e, null, unitId);
+        } catch (Exception e) {
+            return SAPErrorCreator.createError("Failed to confirm bgRFC unit.", e);
+        }
+    }
+
+    private static String unitField(BMap<BString, Object> unitInfo, String field) {
+        Object value = unitInfo.get(StringUtils.fromString(field));
+        return value == null ? "" : value.toString();
+    }
+
+    private static JCoFunction lookupFunction(JCoDestination destination, BString functionName)
+            throws JCoException {
+        String name = functionName.toString();
+        if (name.isEmpty()) {
+            throw SAPErrorCreator.fromBError("Function name is empty", null);
+        }
+        JCoRepository repository = destination.getRepository();
+        JCoFunction function = repository.getFunction(name);
+        if (function == null) {
+            throw SAPErrorCreator.fromBError("RFC function '" + name + "' not found in SAP.", null);
+        }
+        return function;
+    }
+
+    private static JCoUnitIdentifier.Type toUnitType(String unitType) {
+        return SAPConstants.Q.equals(unitType) ? JCoUnitIdentifier.Type.TYPE_Q
+                : JCoUnitIdentifier.Type.TYPE_T;
+    }
+
+    private static JCoBackgroundUnitAttributes buildAttributes(BMap<BString, Object> unitConfig) {
+        JCoBackgroundUnitAttributes attributes = JCo.createBackgroundUnitAttributes();
+        attributes.setLock(getBooleanConfig(unitConfig, SAPConstants.LOCK));
+        attributes.setUnitHistory(getBooleanConfig(unitConfig, SAPConstants.UNIT_HISTORY));
+        attributes.setKernelTrace(getBooleanConfig(unitConfig, SAPConstants.KERNEL_TRACE));
+        attributes.setCommitCheckOn(getBooleanConfig(unitConfig, SAPConstants.COMMIT_CHECK));
+        Object programName = unitConfig.get(StringUtils.fromString(SAPConstants.PROGRAM_NAME));
+        if (programName != null) {
+            attributes.setProgramName(programName.toString());
+        }
+        Object transactionCode = unitConfig.get(StringUtils.fromString(SAPConstants.TRANSACTION_CODE));
+        if (transactionCode != null) {
+            attributes.setTransactionCode(transactionCode.toString());
+        }
+        return attributes;
+    }
+
+    private static boolean getBooleanConfig(BMap<BString, Object> config, String key) {
+        Object value = config.get(StringUtils.fromString(key));
+        return value instanceof Boolean && (Boolean) value;
+    }
+}


### PR DESCRIPTION
## Purpose

Adds support for SAP's transactional RFC protocols to the connector: **tRFC**, **qRFC** and **bgRFC**.

Today the connector offers only synchronous `execute` plus the IDoc operations. A synchronous RFC gives no delivery guarantee: if the connection drops after SAP has committed but before the response is received, the caller cannot tell whether the call executed, and retrying risks posting the same business document twice. tRFC/qRFC/bgRFC are SAP's answer to exactly that, and they are what integrations posting documents into SAP (goods movements, orders, financial postings) need.

## New client operations

| Operation | Protocol | Semantics |
|---|---|---|
| `sendTRfc(functionName, importParams, tid?, autoConfirm?)` | tRFC | Exactly-once; returns the TID used |
| `sendQRfc(functionName, queueName, importParams, tid?, autoConfirm?)` | qRFC | Exactly-once-in-order via an inbound queue |
| `sendBgRfcUnit(FunctionCall[], BgRfcUnitConfig)` | bgRFC | One or more calls as a single LUW; type `Q` when `queueNames` is set, else type `T` |
| `getBgRfcUnitState(unit)` / `confirmBgRfcUnit(unit)` | bgRFC | Unit state polling and confirmation |
| `createTid()` / `confirmTid(tid)` | tRFC/qRFC | Manual TID lifecycle for retry flows |

### Delivery semantics

The value of these protocols is entirely in the identifier lifecycle, so the API keeps that identifier reachable rather than hiding it:

- A failed send returns a `TransactionError` whose detail carries the `tid` or `unitId` already created. Retrying under the same identifier is what makes delivery exactly-once — SAP recognises it and refuses to execute twice.
- `autoConfirm` (default `true`) keeps the common case a one-liner. A real retry loop sets `autoConfirm = false`, retries under one TID until it succeeds, then calls `confirmTid`. Confirming is deliberately not automatic in that mode, because a confirmed TID is forgotten by the backend and a later resend under it would execute again.
- A confirmation failure *after* a successful send is logged rather than surfaced: the call was already delivered, so failing would push the caller into re-posting a completed update.

For bgRFC the state machine is exposed as SAP defines it — `COMMITTED` means processing finished and the unit can be confirmed; `CONFIRMED` occurs only after the client confirms.

## Parameter handling

Transactional calls typically target function modules whose payload lives in **table parameters**, which the existing `execute` path cannot express (it accepts flat values and populates only the import list).

A new `ParameterProcessor` routes each parameter to the import, changing or table list it belongs to, based on the function's metadata, and supports table parameters (arrays of records), nested structures, `time:Date`, `byte[]`/RAW, byte scalars, and nilable values. An unknown parameter name fails fast naming the parameter and the function module.

## Included defect fix

`Client.init` and `Listener.init` each constructed a new `BallerinaDestinationDataProvider` and called `Environment.registerDestinationDataProvider`. JCo permits exactly **one** per JVM and throws on a second registration, which the init path converted into a generic `Client initialization failed.`

Effect on current `main`: **any program creating a second `jco:Client`, or a client alongside a `jco:Listener`, fails to initialise.** A single process-wide provider is now registered once, with each client/listener adding its destination to it. Covered by `testMultipleClients`.

## Testing

29 tests: 2 always-on plus 27 gated behind `enableLiveTests`, all passing against an SAP ECC test system (release 750, kernel 753).

Verified at data level through `RFC_READ_TABLE`, independently of connector code:

- **tRFC exactly-once** — the same payload sent twice under one unconfirmed TID produces exactly one row. Across four runs (8 sends) the backend holds 4 rows.
- **bgRFC exactly-once** — committing the same explicit unit ID twice executes once.
- **bgRFC unit atomicity** — both calls of a two-call type T unit land together, in order.
- **Type conversion** — `STFC_STRUCTURE`'s `RFCTEST` shape (FLTP, INT1/2/4, RAW, DATS, TIMS, CHAR) passed as an IMPORT structure and a TABLES table in one call; `STFC_CHANGING` covers changing-parameter routing. Because those modules echo rather than persist, the encoding was checked off the wire from the payload SAP stores in `TRFCQDATA`: a `time:Date` of 2026-08-18 encodes as DATS `20260818` and 14:05:12 as TIMS `140512`.
- **Multi-list routing** — proven positively: setting the `RESTART_QNAME` import parameter alongside the table parameter made SAP divert the call to a restart queue.
- Multi-row tables preserving order, empty tables, unicode payloads, concurrent sends through one client, and identifier-lifecycle edge cases.

Two observations recorded because they are **not** connector defects, confirmed by isolating them with raw JCo: `lock: true` does not hold a unit back on that system (the flag is transmitted — `isUnitLocked()` is `true` — but holding depends on the bgRFC scheduler configuration); and `RFCINT1 = 255` raises `CONVT_OVERFLOW` because `STFC_STRUCTURE`'s ABAP body increments `RFCTABLE`'s numeric fields.

qRFC ordering is verified at queue level (entries land in `TRFCQIN` in send order with ascending counters). They are not drained on a stock test system because the inbound queue is not registered with the QIN scheduler (`SMQR`) — draining is a backend configuration concern; placing calls on the queue in order is the connector's responsibility.

## Notes

- The JCo/IDoc jars remain `provided` scope and are not redistributed.
- Developed against SAP JCo 3.1.13.
- `Dependencies.toml` is intentionally left at the upstream baseline so the build regenerates it for the CI distribution version.
- Worth documenting for users separately: JCo refuses to run from a repackaged archive, so bundling `sapjco3.jar` into a Ballerina fat executable jar fails at startup with *"Illegal JCo archive"*. Declaring the SAP jars `provided` in the application and supplying them on the classpath is the working setup.
