### PR TITLE
Add transactional RFC support for tRFC, qRFC, and bgRFC

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -71,6 +71,91 @@ public isolated client class Client {
         'class: "io.ballerina.lib.sap.Client"
     } external;
 
+    # Creates a transaction ID (TID) on the SAP system for use with `sendTRfc` or `sendQRfc`.
+    # Obtain the TID before the first send so that every retry can reuse it.
+    #
+    # + return - The TID, or an error if it cannot be created
+    isolated remote function createTid() returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Confirms a transaction ID so that the SAP system can discard its record of it. Confirm only
+    # after the call has been delivered. A confirmed TID must not be reused, because the system
+    # forgets it and a resend under it would execute the call again.
+    #
+    # + tid - The TID to confirm. Must be exactly 24 characters long.
+    # + return - An error if the confirmation fails
+    isolated remote function confirmTid(string tid) returns Error? = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Calls an RFC-enabled function module as a transactional RFC (tRFC), which the SAP system
+    # executes exactly once. The call is asynchronous, so export and table values the function
+    # module produces are discarded and only the TID is returned. Use `execute` when the result
+    # is needed.
+    #
+    # + functionName - Name of the RFC function module to call
+    # + parameters - Input parameters organised by category
+    # + tid - The transaction ID to use. If not provided, one is created automatically. A
+    #         supplied TID must be exactly 24 characters long; the content is unrestricted, so
+    #         it may be derived from an application idempotency key.
+    # + autoConfirm - Whether to confirm the TID after a successful send. Set this to false to
+    #                 retry a failed send under the same TID, then call `confirmTid` once the
+    #                 send finally succeeds.
+    # + return - The TID the call was sent under, or an error if the send fails
+    isolated remote function sendTRfc(string functionName, RfcParameters parameters = {},
+            string? tid = (), boolean autoConfirm = true) returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Calls an RFC-enabled function module as a queued RFC (qRFC). Calls placed on the same
+    # inbound queue are executed exactly once and in the order they were sent.
+    #
+    # + functionName - Name of the RFC function module to call
+    # + queueName - The SAP inbound queue that serialises the calls
+    # + parameters - Input parameters organised by category
+    # + tid - The transaction ID to use. If not provided, one is created automatically. A
+    #         supplied TID must be exactly 24 characters long.
+    # + autoConfirm - Whether to confirm the TID after a successful send
+    # + return - The TID the call was sent under, or an error if the send fails
+    isolated remote function sendQRfc(string functionName, string queueName,
+            RfcParameters parameters = {}, string? tid = (), boolean autoConfirm = true)
+            returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Commits one or more function calls to the SAP system as a single bgRFC unit of work. The
+    # calls are applied together or not at all. Supplying `queueNames` makes the unit type `Q`,
+    # which is executed in order within those queues; otherwise it is type `T`.
+    #
+    # + functionCalls - The calls that make up the unit
+    # + unitConfig - Configuration for the unit
+    # + return - The ID and type of the committed unit, or an error if the commit fails
+    isolated remote function sendBgRfcUnit(FunctionCall[] functionCalls, BgRfcUnitConfig unitConfig = {})
+            returns BgRfcUnitInfo|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Reads the processing state of a bgRFC unit. `COMMITTED` means processing finished and the
+    # unit is ready to be confirmed. `CONFIRMED` occurs only after `confirmBgRfcUnit`, so waiting
+    # for it before confirming would never return.
+    #
+    # + unit - The unit returned by `sendBgRfcUnit`
+    # + return - The state of the unit, or an error if the state cannot be read
+    isolated remote function getBgRfcUnitState(BgRfcUnitInfo unit)
+            returns BgRfcUnitState|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Confirms a bgRFC unit so that the SAP system can delete its status record. Confirm once
+    # `getBgRfcUnitState` reports `COMMITTED`. A confirmed unit ID must not be reused.
+    #
+    # + unit - The unit returned by `sendBgRfcUnit`
+    # + return - An error if the confirmation fails
+    isolated remote function confirmBgRfcUnit(BgRfcUnitInfo unit) returns Error? = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
     # Releases the JCo destination registered for this client. Call this when the client is
     # no longer needed to free the destination ID for reuse. Calling this more than once is
     # safe.

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org).
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -89,6 +89,66 @@ public type RfcParameters record {|
     map<RfcRecord[]> tableParameters?;
 |};
 
+# A single function invocation inside a bgRFC unit of work.
+public type FunctionCall record {|
+    # Name of the RFC-enabled function module to call
+    string functionName;
+    # Input parameters for the call, organised by category
+    RfcParameters parameters = {};
+|};
+
+# Type of a bgRFC unit: transactional (exactly-once) or queued (exactly-once in order).
+public enum BgRfcUnitType {
+    # Transactional unit, executed exactly once
+    BGRFC_TYPE_T = "T",
+    # Queued unit, executed exactly once and in order within its queues
+    BGRFC_TYPE_Q = "Q"
+};
+
+# Processing state of a bgRFC unit as reported by the SAP system.
+public enum BgRfcUnitState {
+    # The SAP system has no record of the unit
+    NOT_FOUND,
+    # The unit is currently being processed
+    IN_PROCESS,
+    # Processing finished; the unit is ready to be confirmed
+    COMMITTED,
+    # The unit was confirmed by the client
+    CONFIRMED,
+    # Processing failed and the unit was rolled back
+    ROLLED_BACK
+};
+
+# Configuration for a bgRFC unit of work.
+public type BgRfcUnitConfig record {|
+    # A 32-character hexadecimal unit ID. Supply one derived from a business key to make a
+    # repeated submission idempotent. If omitted, a unique ID is generated.
+    string unitId?;
+    # Inbound queues the unit is assigned to. Supplying at least one queue makes the unit
+    # type `Q`; otherwise it is type `T`.
+    string[] queueNames = [];
+    # Holds the unit back from processing until it is unlocked in the SAP system
+    boolean 'lock = false;
+    # Records the unit history in the SAP system
+    boolean unitHistory = false;
+    # Enables kernel tracing for the unit
+    boolean kernelTrace = false;
+    # Checks whether the unit can be processed before committing it
+    boolean commitCheck = false;
+    # Calling program name recorded with the unit
+    string programName?;
+    # Transaction code recorded with the unit
+    string transactionCode?;
+|};
+
+# Identifies a bgRFC unit that was committed to the SAP system.
+public type BgRfcUnitInfo record {|
+    # The 32-character hexadecimal ID of the unit
+    string unitId;
+    # The type of the unit
+    BgRfcUnitType unitType;
+|};
+
 # Error detail for JCo-origin errors, providing the JCo error group and SAP exception key.
 public type JCoErrorDetail record {|
     # JCo error group identifier
@@ -146,6 +206,20 @@ public type ConfigurationError distinct error;
 # Raised when an unexpected error occurs during RFC execution or other runtime operations.
 public type ExecutionError distinct error;
 
+# Error detail for a failed transactional call, carrying the identifier the call was using so
+# that the caller can retry under it without risking a duplicate execution.
+public type TransactionErrorDetail record {|
+    *JCoErrorDetail;
+    # Transaction ID of the failed tRFC or qRFC call, when one had already been created
+    string tid?;
+    # Unit ID of the failed bgRFC unit operation
+    string unitId?;
+|};
+
+# Raised when a transactional call (tRFC, qRFC, or bgRFC) fails. Retrying under the `tid` or
+# `unitId` carried in the detail preserves the exactly-once guarantee.
+public type TransactionError distinct error<TransactionErrorDetail>;
+
 # Represents all errors that can be returned by the SAP JCo connector.
 public type Error ConnectionError|LogonError|ResourceError|SystemError|AbapApplicationError
-    |JCoError|IDocError|ParameterError|ConfigurationError|ExecutionError;
+    |JCoError|IDocError|ParameterError|ConfigurationError|ExecutionError|TransactionError;

--- a/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
@@ -43,6 +43,32 @@ public class SAPConstants {
     public static final BString RFC_IMPORT_PARAMETERS = StringUtils.fromString("importParameters");
     public static final BString RFC_TABLE_PARAMETERS = StringUtils.fromString("tableParameters");
 
+    // Transactional RFC (tRFC / qRFC / bgRFC)
+    public static final int TID_LENGTH = 24;
+    public static final int UNIT_ID_LENGTH = 32;
+    public static final String BGRFC_TYPE_T = "T";
+    public static final String BGRFC_TYPE_Q = "Q";
+    public static final String BGRFC_UNIT_INFO_RECORD = "BgRfcUnitInfo";
+
+    // FunctionCall field names
+    public static final BString BGRFC_FUNCTION_NAME = StringUtils.fromString("functionName");
+    public static final BString BGRFC_PARAMETERS = StringUtils.fromString("parameters");
+
+    // BgRfcUnitConfig / BgRfcUnitInfo field names
+    public static final BString BGRFC_UNIT_ID = StringUtils.fromString("unitId");
+    public static final BString BGRFC_UNIT_TYPE = StringUtils.fromString("unitType");
+    public static final BString BGRFC_QUEUE_NAMES = StringUtils.fromString("queueNames");
+    public static final BString BGRFC_LOCK = StringUtils.fromString("lock");
+    public static final BString BGRFC_UNIT_HISTORY = StringUtils.fromString("unitHistory");
+    public static final BString BGRFC_KERNEL_TRACE = StringUtils.fromString("kernelTrace");
+    public static final BString BGRFC_COMMIT_CHECK = StringUtils.fromString("commitCheck");
+    public static final BString BGRFC_PROGRAM_NAME = StringUtils.fromString("programName");
+    public static final BString BGRFC_TRANSACTION_CODE = StringUtils.fromString("transactionCode");
+
+    // TransactionErrorDetail field keys
+    public static final BString DETAIL_TID = StringUtils.fromString("tid");
+    public static final BString DETAIL_UNIT_ID = StringUtils.fromString("unitId");
+
 
     // Class names
     public static final String JCO_STRING = "java.lang.String";
@@ -72,6 +98,7 @@ public class SAPConstants {
     public static final String PARAMETER_ERROR_TYPE         = "ParameterError";
     public static final String CONFIGURATION_ERROR_TYPE     = "ConfigurationError";
     public static final String EXECUTION_ERROR_TYPE         = "ExecutionError";
+    public static final String TRANSACTION_ERROR_TYPE       = "TransactionError";
 
     // JCoErrorDetail field keys
     public static final BString DETAIL_ERROR_GROUP      = StringUtils.fromString("errorGroup");

--- a/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */

--- a/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
@@ -214,6 +214,31 @@ public class SAPErrorCreator {
     // Private helpers
     // -------------------------------------------------------------------------
 
+    /**
+     * Creates a {@code TransactionError} for a failed tRFC, qRFC, or bgRFC operation, carrying the
+     * identifier the operation was using. The identifier is what makes the delivery repeatable:
+     * retrying under the same TID or unit ID lets SAP recognise the duplicate and execute the call
+     * only once, so it is surfaced to the caller rather than discarded with the exception.
+     *
+     * @param message a human-readable description of what failed
+     * @param e       the originating JCo exception
+     * @param tid     the transaction ID in use, or {@code null} if none had been created
+     * @param unitId  the bgRFC unit ID in use, or {@code null} if not a unit operation
+     * @return a Ballerina {@code TransactionError}
+     */
+    public static BError createTransactionError(String message, JCoException e, String tid, String unitId) {
+        BMap<BString, Object> detail = buildJCoDetail(e.getGroup(), e.getKey());
+        if (tid != null) {
+            detail.put(SAPConstants.DETAIL_TID, StringUtils.fromString(tid));
+        }
+        if (unitId != null) {
+            detail.put(SAPConstants.DETAIL_UNIT_ID, StringUtils.fromString(unitId));
+        }
+        String detailed = message + " " + firstLine(e.getMessage(), "Unknown JCo error");
+        return ErrorCreator.createError(ModuleUtils.getModule(), SAPConstants.TRANSACTION_ERROR_TYPE,
+                StringUtils.fromString(detailed), ErrorCreator.createError(e), detail);
+    }
+
     private static BMap<BString, Object> buildJCoDetail(int errorGroup, String key) {
         BMap<BString, Object> detail = ValueCreator.createMapValue(
                 TypeCreator.createMapType(PredefinedTypes.TYPE_ANYDATA));

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.lib.sap;
+
+import com.sap.conn.jco.JCo;
+import com.sap.conn.jco.JCoBackgroundUnitAttributes;
+import com.sap.conn.jco.JCoDestination;
+import com.sap.conn.jco.JCoException;
+import com.sap.conn.jco.JCoFunction;
+import com.sap.conn.jco.JCoFunctionUnit;
+import com.sap.conn.jco.JCoParameterList;
+import com.sap.conn.jco.JCoRepository;
+import com.sap.conn.jco.JCoUnitIdentifier;
+import io.ballerina.lib.sap.parameterprocessor.ImportParameterProcessor;
+import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Native implementations of the transactional RFC operations on the Ballerina SAP JCo
+ * {@code Client}: tRFC and qRFC function calls, and bgRFC units of work.
+ * <p>
+ * All three protocols give the caller a guarantee that a plain {@code execute} cannot: the call
+ * is applied exactly once, even if the caller retries because it never learned the outcome of an
+ * earlier attempt. The guarantee is carried by an identifier — a transaction ID (TID) for
+ * tRFC/qRFC, a unit ID for bgRFC — which SAP remembers until the caller confirms it. Each
+ * operation therefore returns or accepts that identifier rather than hiding it.
+ */
+public final class Transactions {
+
+    private static final Logger logger = LoggerFactory.getLogger(Transactions.class);
+
+    private Transactions() {
+    }
+
+    /**
+     * Creates a transaction ID on the SAP system.
+     *
+     * @param client the Ballerina {@code Client} object
+     * @return the TID as a Ballerina string, or a Ballerina {@code Error} on failure
+     */
+    public static Object createTid(BObject client) {
+        try {
+            JCoDestination destination = destinationOf(client);
+            return StringUtils.fromString(destination.createTID());
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.fromJCoException(e);
+        }
+    }
+
+    /**
+     * Confirms a transaction ID so that the SAP system can discard its record of it.
+     *
+     * @param client the Ballerina {@code Client} object
+     * @param tid    the TID to confirm
+     * @return {@code null} on success, or a Ballerina {@code Error} on failure
+     */
+    public static Object confirmTid(BObject client, BString tid) {
+        String tidStr = tid.getValue();
+        try {
+            validateTid(tidStr);
+            destinationOf(client).confirmTID(tidStr);
+            return null;
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError(
+                    "Failed to confirm TID '" + tidStr + "'.", e, tidStr, null);
+        }
+    }
+
+    /**
+     * Executes a function module as a transactional RFC (tRFC).
+     *
+     * @param client       the Ballerina {@code Client} object
+     * @param functionName name of the RFC-enabled function module
+     * @param parameters   the {@code RfcParameters} record holding import and table parameters
+     * @param tid          a caller-supplied TID, or {@code null} to create one
+     * @param autoConfirm  whether to confirm the TID after a successful send
+     * @return the TID the call was sent under, or a Ballerina {@code Error} on failure
+     */
+    public static Object sendTRfc(BObject client, BString functionName, BMap<BString, Object> parameters,
+                                  Object tid, boolean autoConfirm) {
+        return send(client, functionName, parameters, tid, null, autoConfirm);
+    }
+
+    /**
+     * Executes a function module as a queued RFC (qRFC) on the given inbound queue.
+     *
+     * @param client       the Ballerina {@code Client} object
+     * @param functionName name of the RFC-enabled function module
+     * @param queueName    the SAP inbound queue that serialises the calls
+     * @param parameters   the {@code RfcParameters} record holding import and table parameters
+     * @param tid          a caller-supplied TID, or {@code null} to create one
+     * @param autoConfirm  whether to confirm the TID after a successful send
+     * @return the TID the call was sent under, or a Ballerina {@code Error} on failure
+     */
+    public static Object sendQRfc(BObject client, BString functionName, BString queueName,
+                                  BMap<BString, Object> parameters, Object tid, boolean autoConfirm) {
+        String queue = queueName.getValue();
+        if (queue.isEmpty()) {
+            return SAPErrorCreator.createParameterError("Queue name is empty.");
+        }
+        return send(client, functionName, parameters, tid, queue, autoConfirm);
+    }
+
+    private static Object send(BObject client, BString functionName, BMap<BString, Object> parameters,
+                               Object tid, String queueName, boolean autoConfirm) {
+        String tidStr = null;
+        try {
+            if (tid instanceof BString) {
+                validateTid(((BString) tid).getValue());
+            }
+            JCoDestination destination = destinationOf(client);
+            JCoFunction function = prepareFunction(destination, functionName, parameters);
+
+            tidStr = (tid instanceof BString) ? ((BString) tid).getValue() : destination.createTID();
+            if (queueName == null) {
+                function.execute(destination, tidStr);
+            } else {
+                function.execute(destination, tidStr, queueName);
+            }
+            if (autoConfirm) {
+                confirmQuietly(destination, tidStr);
+            }
+            return StringUtils.fromString(tidStr);
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            String protocol = queueName == null ? "tRFC" : "qRFC";
+            return SAPErrorCreator.createTransactionError(
+                    protocol + " call to '" + functionName + "' failed.", e, tidStr, null);
+        }
+    }
+
+    // A confirmation failure does not undo the delivery: the call is already recorded in SAP, and
+    // retrying it would not create a duplicate. Failing the operation here would push the caller
+    // into re-sending something that already succeeded, so this is logged rather than surfaced.
+    private static void confirmQuietly(JCoDestination destination, String tid) {
+        try {
+            destination.confirmTID(tid);
+        } catch (JCoException e) {
+            logger.warn("Call was delivered, but confirming TID {} failed. SAP will discard the TID "
+                    + "record on its own schedule. Cause: {}", tid, e.getMessage());
+        }
+    }
+
+    /**
+     * Commits one or more function calls to SAP as a single bgRFC unit of work.
+     *
+     * @param client        the Ballerina {@code Client} object
+     * @param functionCalls the {@code FunctionCall} records making up the unit
+     * @param unitConfig    the {@code BgRfcUnitConfig} record
+     * @return a {@code BgRfcUnitInfo} record, or a Ballerina {@code Error} on failure
+     */
+    @SuppressWarnings("unchecked")
+    public static Object sendBgRfcUnit(BObject client, BArray functionCalls,
+                                       BMap<BString, Object> unitConfig) {
+        String unitId = null;
+        try {
+            if (functionCalls.size() == 0) {
+                return SAPErrorCreator.createParameterError(
+                        "A bgRFC unit must contain at least one function call.");
+            }
+            JCoDestination destination = destinationOf(client);
+
+            Object configuredId = unitConfig.get(SAPConstants.BGRFC_UNIT_ID);
+            if (configuredId != null) {
+                validateUnitId(configuredId.toString());
+            }
+            JCoBackgroundUnitAttributes attributes = buildAttributes(unitConfig);
+            JCoFunctionUnit unit = (configuredId == null)
+                    ? JCo.createFunctionUnit(attributes)
+                    : JCo.createFunctionUnit(configuredId.toString(), attributes);
+
+            BArray queueNames = (BArray) unitConfig.get(SAPConstants.BGRFC_QUEUE_NAMES);
+            if (queueNames != null) {
+                for (int i = 0; i < queueNames.size(); i++) {
+                    String queue = queueNames.getBString(i).getValue();
+                    if (!unit.addQueueName(queue)) {
+                        return SAPErrorCreator.createParameterError(
+                                "Queue name '" + queue + "' was rejected by JCo.");
+                    }
+                }
+            }
+
+            for (int i = 0; i < functionCalls.size(); i++) {
+                BMap<BString, Object> call = (BMap<BString, Object>) functionCalls.get(i);
+                BString name = (BString) call.get(SAPConstants.BGRFC_FUNCTION_NAME);
+                BMap<BString, Object> params = (BMap<BString, Object>)
+                        call.get(SAPConstants.BGRFC_PARAMETERS);
+                unit.addFunction(prepareFunction(destination, name, params));
+            }
+
+            JCoUnitIdentifier identifier = unit.getIdentifier();
+            unitId = identifier.getID();
+            unit.commit(destination);
+            return createUnitInfo(unitId, identifier.getType());
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError("bgRFC unit commit failed.", e, null, unitId);
+        }
+    }
+
+    /**
+     * Reads the processing state of a bgRFC unit from the SAP system.
+     *
+     * @param client   the Ballerina {@code Client} object
+     * @param unitInfo the {@code BgRfcUnitInfo} record identifying the unit
+     * @return the state name as a Ballerina string, or a Ballerina {@code Error} on failure
+     */
+    public static Object getBgRfcUnitState(BObject client, BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
+        try {
+            JCoUnitIdentifier identifier = toIdentifier(unitInfo);
+            return StringUtils.fromString(destinationOf(client).getFunctionUnitState(identifier).name());
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError(
+                    "Failed to read the state of bgRFC unit '" + unitId + "'.", e, null, unitId);
+        }
+    }
+
+    /**
+     * Confirms a processed bgRFC unit so that SAP can delete its status record.
+     *
+     * @param client   the Ballerina {@code Client} object
+     * @param unitInfo the {@code BgRfcUnitInfo} record identifying the unit
+     * @return {@code null} on success, or a Ballerina {@code Error} on failure
+     */
+    public static Object confirmBgRfcUnit(BObject client, BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
+        try {
+            destinationOf(client).confirmFunctionUnit(toIdentifier(unitInfo));
+            return null;
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError(
+                    "Failed to confirm bgRFC unit '" + unitId + "'.", e, null, unitId);
+        }
+    }
+
+    /** Looks the function up and binds its import and table parameters, mirroring {@code execute}. */
+    @SuppressWarnings("unchecked")
+    private static JCoFunction prepareFunction(JCoDestination destination, BString functionName,
+                                               BMap<BString, Object> parameters) throws JCoException {
+        String name = functionName.getValue();
+        if (name.isEmpty()) {
+            throw SAPErrorCreator.createParameterError("Function name is empty.");
+        }
+        JCoRepository repository = destination.getRepository();
+        JCoFunction function = repository.getFunction(name);
+        if (function == null) {
+            throw SAPErrorCreator.createParameterError("RFC function '" + name + "' not found in SAP.");
+        }
+        if (parameters == null) {
+            return function;
+        }
+
+        BMap<BString, Object> importParameters =
+                (BMap<BString, Object>) parameters.get(SAPConstants.RFC_IMPORT_PARAMETERS);
+        BMap<BString, Object> tableParameters =
+                (BMap<BString, Object>) parameters.get(SAPConstants.RFC_TABLE_PARAMETERS);
+
+        if (importParameters != null) {
+            JCoParameterList importList = function.getImportParameterList();
+            if (importList == null) {
+                throw SAPErrorCreator.createParameterError("RFC function '" + name
+                        + "' has no import parameters but importParameters were provided.");
+            }
+            ImportParameterProcessor.setImportParams(importList, importParameters);
+        }
+        if (tableParameters != null) {
+            JCoParameterList tableList = function.getTableParameterList();
+            if (tableList == null) {
+                throw SAPErrorCreator.createParameterError("RFC function '" + name
+                        + "' has no table parameters but tableParameters were provided.");
+            }
+            ImportParameterProcessor.setTableParams(tableList, tableParameters);
+        }
+        return function;
+    }
+
+    private static BMap<BString, Object> createUnitInfo(String unitId, JCoUnitIdentifier.Type type) {
+        BMap<BString, Object> info = ValueCreator.createRecordValue(
+                ModuleUtils.getModule(), SAPConstants.BGRFC_UNIT_INFO_RECORD);
+        info.put(SAPConstants.BGRFC_UNIT_ID, StringUtils.fromString(unitId));
+        info.put(SAPConstants.BGRFC_UNIT_TYPE, StringUtils.fromString(
+                type == JCoUnitIdentifier.Type.TYPE_Q ? SAPConstants.BGRFC_TYPE_Q : SAPConstants.BGRFC_TYPE_T));
+        return info;
+    }
+
+    private static JCoUnitIdentifier toIdentifier(BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
+        validateUnitId(unitId);
+        JCoUnitIdentifier.Type type =
+                SAPConstants.BGRFC_TYPE_Q.equals(unitField(unitInfo, SAPConstants.BGRFC_UNIT_TYPE))
+                        ? JCoUnitIdentifier.Type.TYPE_Q
+                        : JCoUnitIdentifier.Type.TYPE_T;
+        return JCo.createUnitIdentifier(unitId, type);
+    }
+
+    private static JCoBackgroundUnitAttributes buildAttributes(BMap<BString, Object> unitConfig) {
+        JCoBackgroundUnitAttributes attributes = JCo.createBackgroundUnitAttributes();
+        attributes.setLock(booleanConfig(unitConfig, SAPConstants.BGRFC_LOCK));
+        attributes.setUnitHistory(booleanConfig(unitConfig, SAPConstants.BGRFC_UNIT_HISTORY));
+        attributes.setKernelTrace(booleanConfig(unitConfig, SAPConstants.BGRFC_KERNEL_TRACE));
+        attributes.setCommitCheckOn(booleanConfig(unitConfig, SAPConstants.BGRFC_COMMIT_CHECK));
+        Object programName = unitConfig.get(SAPConstants.BGRFC_PROGRAM_NAME);
+        if (programName != null) {
+            attributes.setProgramName(programName.toString());
+        }
+        Object transactionCode = unitConfig.get(SAPConstants.BGRFC_TRANSACTION_CODE);
+        if (transactionCode != null) {
+            attributes.setTransactionCode(transactionCode.toString());
+        }
+        return attributes;
+    }
+
+    private static boolean booleanConfig(BMap<BString, Object> config, BString key) {
+        Object value = config.get(key);
+        return value instanceof Boolean && (Boolean) value;
+    }
+
+    private static String unitField(BMap<BString, Object> unitInfo, BString field) {
+        Object value = unitInfo.get(field);
+        return value == null ? "" : value.toString();
+    }
+
+    private static JCoDestination destinationOf(BObject client) {
+        JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+        if (destination == null) {
+            throw SAPErrorCreator.createConfigError("Client is closed or not initialized.");
+        }
+        return destination;
+    }
+
+    // JCo splits a TID positionally into four fixed-width character fields, so a shorter value
+    // raises a raw StringIndexOutOfBoundsException and a longer one is silently truncated —
+    // which would break exactly-once, because SAP would record a different identifier than the
+    // caller believes it used. The content is deliberately not restricted: SAP stores the TID
+    // components as CHAR, so an application may derive a TID from its own idempotency key.
+    private static void validateTid(String tid) {
+        if (tid == null || tid.length() != SAPConstants.TID_LENGTH) {
+            throw SAPErrorCreator.createParameterError("Invalid transaction ID '" + tid
+                    + "'. A TID must be exactly " + SAPConstants.TID_LENGTH + " characters long.");
+        }
+    }
+
+    // Unit IDs, unlike TIDs, really are 16 bytes in hexadecimal — JCo documents that and rejects
+    // bad values in createUnitIdentifier. JCo.createFunctionUnit however accepts any length, so a
+    // malformed ID would otherwise surface only later when the unit is queried.
+    private static void validateUnitId(String unitId) {
+        if (!isHexOfLength(unitId, SAPConstants.UNIT_ID_LENGTH)) {
+            throw SAPErrorCreator.createParameterError("Invalid bgRFC unit ID '" + unitId
+                    + "'. A unit ID must be a " + SAPConstants.UNIT_ID_LENGTH
+                    + "-character hexadecimal string.");
+        }
+    }
+
+    private static boolean isHexOfLength(String value, int length) {
+        if (value == null || value.length() != length) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *    http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied. See the License for the
+ * KIND, either express or implied.  See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */


### PR DESCRIPTION
## Purpose

Adds SAP's transactional RFC protocols — **tRFC**, **qRFC**, and **bgRFC** — for function-module calls.

`execute` calls a function module synchronously, and `sendIDoc` already delivers IDocs over tRFC/qRFC with a TID. Function-module calls, though, still have no delivery guarantee: if the connection drops after SAP has committed but before the response arrives, the caller cannot tell whether the call ran, and retrying may post the same business document twice. These three protocols are SAP's answer to exactly that, and they are what integrations posting goods movements, orders, or financial documents need.

## New client operations

| Operation | Protocol | Guarantee |
|---|---|---|
| `sendTRfc(functionName, parameters, tid?, autoConfirm?)` | tRFC | Exactly-once; returns the TID |
| `sendQRfc(functionName, queueName, parameters, tid?, autoConfirm?)` | qRFC | Exactly-once and in order, per inbound queue |
| `sendBgRfcUnit(FunctionCall[], BgRfcUnitConfig)` | bgRFC | One or more calls as a single LUW; type `Q` when `queueNames` is set, else type `T` |
| `getBgRfcUnitState(unit)` / `confirmBgRfcUnit(unit)` | bgRFC | Unit state polling and confirmation |
| `createTid()` / `confirmTid(tid)` | tRFC/qRFC | Explicit TID lifecycle for retry flows |


## Testing

Verified end to end against a live SAP ECC system (release 750, kernel 753), 11/11 checks passing, with results read back independently from table `TCPIC` through `RFC_READ_TABLE`:

```
TRFC-ONCE   x1   sent TWICE under one TID, stored ONCE
BIZTID      x1   24-character non-hex business-key TID accepted
BG-T-1 / BG-T-2  same timestamp, sequence 1/2 - one unit of work
(no BAD row)     wrong-length TID rejected before anything is sent
```
