### PR TITLE
Add transactional RFC support for tRFC, qRFC, and bgRFC

### DIFF
--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -71,6 +71,91 @@ public isolated client class Client {
         'class: "io.ballerina.lib.sap.Client"
     } external;
 
+    # Creates a transaction ID (TID) on the SAP system for use with `sendTRfc` or `sendQRfc`.
+    # Obtain the TID before the first send so that every retry can reuse it.
+    #
+    # + return - The TID, or an error if it cannot be created
+    isolated remote function createTid() returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Confirms a transaction ID so that the SAP system can discard its record of it. Confirm only
+    # after the call has been delivered. A confirmed TID must not be reused, because the system
+    # forgets it and a resend under it would execute the call again.
+    #
+    # + tid - The TID to confirm. Must be exactly 24 characters long.
+    # + return - An error if the confirmation fails
+    isolated remote function confirmTid(string tid) returns Error? = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Calls an RFC-enabled function module as a transactional RFC (tRFC), which the SAP system
+    # executes exactly once. The call is asynchronous, so export and table values the function
+    # module produces are discarded and only the TID is returned. Use `execute` when the result
+    # is needed.
+    #
+    # + functionName - Name of the RFC function module to call
+    # + parameters - Input parameters organised by category
+    # + tid - The transaction ID to use. If not provided, one is created automatically. A
+    #         supplied TID must be exactly 24 characters long; the content is unrestricted, so
+    #         it may be derived from an application idempotency key.
+    # + autoConfirm - Whether to confirm the TID after a successful send. Set this to false to
+    #                 retry a failed send under the same TID, then call `confirmTid` once the
+    #                 send finally succeeds.
+    # + return - The TID the call was sent under, or an error if the send fails
+    isolated remote function sendTRfc(string functionName, RfcParameters parameters = {},
+            string? tid = (), boolean autoConfirm = true) returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Calls an RFC-enabled function module as a queued RFC (qRFC). Calls placed on the same
+    # inbound queue are executed exactly once and in the order they were sent.
+    #
+    # + functionName - Name of the RFC function module to call
+    # + queueName - The SAP inbound queue that serialises the calls
+    # + parameters - Input parameters organised by category
+    # + tid - The transaction ID to use. If not provided, one is created automatically. A
+    #         supplied TID must be exactly 24 characters long.
+    # + autoConfirm - Whether to confirm the TID after a successful send
+    # + return - The TID the call was sent under, or an error if the send fails
+    isolated remote function sendQRfc(string functionName, string queueName,
+            RfcParameters parameters = {}, string? tid = (), boolean autoConfirm = true)
+            returns string|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Commits one or more function calls to the SAP system as a single bgRFC unit of work. The
+    # calls are applied together or not at all. Supplying `queueNames` makes the unit type `Q`,
+    # which is executed in order within those queues; otherwise it is type `T`.
+    #
+    # + functionCalls - The calls that make up the unit
+    # + unitConfig - Configuration for the unit
+    # + return - The ID and type of the committed unit, or an error if the commit fails
+    isolated remote function sendBgRfcUnit(FunctionCall[] functionCalls, BgRfcUnitConfig unitConfig = {})
+            returns BgRfcUnitInfo|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Reads the processing state of a bgRFC unit. `COMMITTED` means processing finished and the
+    # unit is ready to be confirmed. `CONFIRMED` occurs only after `confirmBgRfcUnit`, so waiting
+    # for it before confirming would never return.
+    #
+    # + unit - The unit returned by `sendBgRfcUnit`
+    # + return - The state of the unit, or an error if the state cannot be read
+    isolated remote function getBgRfcUnitState(BgRfcUnitInfo unit)
+            returns BgRfcUnitState|Error = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
+    # Confirms a bgRFC unit so that the SAP system can delete its status record. Confirm once
+    # `getBgRfcUnitState` reports `COMMITTED`. A confirmed unit ID must not be reused.
+    #
+    # + unit - The unit returned by `sendBgRfcUnit`
+    # + return - An error if the confirmation fails
+    isolated remote function confirmBgRfcUnit(BgRfcUnitInfo unit) returns Error? = @java:Method {
+        'class: "io.ballerina.lib.sap.Transactions"
+    } external;
+
     # Releases the JCo destination registered for this client. Call this when the client is
     # no longer needed to free the destination ID for reuse. Calling this more than once is
     # safe.

--- a/ballerina/client.bal
+++ b/ballerina/client.bal
@@ -85,9 +85,23 @@ public isolated client class Client {
     #
     # + tid - The TID to confirm. Must be exactly 24 characters long.
     # + return - An error if the confirmation fails
-    isolated remote function confirmTid(string tid) returns Error? = @java:Method {
-        'class: "io.ballerina.lib.sap.Transactions"
-    } external;
+    isolated remote function confirmTid(string tid) returns Error? {
+        check validateTid(tid);
+        return confirmTidExternal(self, tid);
+    }
+
+    # Returns the transaction ID to send under: the caller's, once validated, or a new one
+    # obtained from the SAP system when none was supplied.
+    #
+    # + tid - The caller-supplied transaction ID, or `()` to obtain one from SAP
+    # + return - The transaction ID to use, or an error if it is invalid or cannot be obtained
+    isolated function resolveTid(string? tid) returns string|Error {
+        if tid is string {
+            check validateTid(tid);
+            return tid;
+        }
+        return self->createTid();
+    }
 
     # Calls an RFC-enabled function module as a transactional RFC (tRFC), which the SAP system
     # executes exactly once. The call is asynchronous, so export and table values the function
@@ -104,9 +118,11 @@ public isolated client class Client {
     #                 send finally succeeds.
     # + return - The TID the call was sent under, or an error if the send fails
     isolated remote function sendTRfc(string functionName, RfcParameters parameters = {},
-            string? tid = (), boolean autoConfirm = true) returns string|Error = @java:Method {
-        'class: "io.ballerina.lib.sap.Transactions"
-    } external;
+            string? tid = (), boolean autoConfirm = true) returns string|Error {
+        string transactionId = check self.resolveTid(tid);
+        check sendTRfcExternal(self, functionName, parameters, transactionId, autoConfirm);
+        return transactionId;
+    }
 
     # Calls an RFC-enabled function module as a queued RFC (qRFC). Calls placed on the same
     # inbound queue are executed exactly once and in the order they were sent.
@@ -120,21 +136,33 @@ public isolated client class Client {
     # + return - The TID the call was sent under, or an error if the send fails
     isolated remote function sendQRfc(string functionName, string queueName,
             RfcParameters parameters = {}, string? tid = (), boolean autoConfirm = true)
-            returns string|Error = @java:Method {
-        'class: "io.ballerina.lib.sap.Transactions"
-    } external;
+            returns string|Error {
+        if queueName.length() == 0 {
+            return error ParameterError("Queue name is empty.");
+        }
+        string transactionId = check self.resolveTid(tid);
+        check sendQRfcExternal(self, functionName, queueName, parameters, transactionId, autoConfirm);
+        return transactionId;
+    }
 
     # Commits one or more function calls to the SAP system as a single bgRFC unit of work. The
-    # calls are applied together or not at all. Supplying `queueNames` makes the unit type `Q`,
-    # which is executed in order within those queues; otherwise it is type `T`.
+    # calls are applied together or not at all. Supplying `queueNames` makes the unit type Q,
+    # which is executed in order within those queues; otherwise it is type T.
     #
     # + functionCalls - The calls that make up the unit
     # + unitConfig - Configuration for the unit
     # + return - The ID and type of the committed unit, or an error if the commit fails
-    isolated remote function sendBgRfcUnit(FunctionCall[] functionCalls, BgRfcUnitConfig unitConfig = {})
-            returns BgRfcUnitInfo|Error = @java:Method {
-        'class: "io.ballerina.lib.sap.Transactions"
-    } external;
+    isolated remote function sendBgRfcUnit(RemoteFunctionCall[] functionCalls,
+            BgRfcUnitConfig unitConfig = {}) returns BgRfcUnitInfo|Error {
+        if functionCalls.length() == 0 {
+            return error ParameterError("A bgRFC unit must contain at least one function call.");
+        }
+        string? unitId = unitConfig?.unitId;
+        if unitId is string {
+            check validateUnitId(unitId);
+        }
+        return sendBgRfcUnitExternal(self, functionCalls, unitConfig);
+    }
 
     # Reads the processing state of a bgRFC unit. `COMMITTED` means processing finished and the
     # unit is ready to be confirmed. `CONFIRMED` occurs only after `confirmBgRfcUnit`, so waiting
@@ -143,18 +171,20 @@ public isolated client class Client {
     # + unit - The unit returned by `sendBgRfcUnit`
     # + return - The state of the unit, or an error if the state cannot be read
     isolated remote function getBgRfcUnitState(BgRfcUnitInfo unit)
-            returns BgRfcUnitState|Error = @java:Method {
-        'class: "io.ballerina.lib.sap.Transactions"
-    } external;
+            returns BgRfcUnitState|Error {
+        check validateUnitId(unit.unitId);
+        return getBgRfcUnitStateExternal(self, unit);
+    }
 
     # Confirms a bgRFC unit so that the SAP system can delete its status record. Confirm once
     # `getBgRfcUnitState` reports `COMMITTED`. A confirmed unit ID must not be reused.
     #
     # + unit - The unit returned by `sendBgRfcUnit`
     # + return - An error if the confirmation fails
-    isolated remote function confirmBgRfcUnit(BgRfcUnitInfo unit) returns Error? = @java:Method {
-        'class: "io.ballerina.lib.sap.Transactions"
-    } external;
+    isolated remote function confirmBgRfcUnit(BgRfcUnitInfo unit) returns Error? {
+        check validateUnitId(unit.unitId);
+        return confirmBgRfcUnitExternal(self, unit);
+    }
 
     # Releases the JCo destination registered for this client. Call this when the client is
     # no longer needed to free the destination ID for reuse. Calling this more than once is
@@ -168,6 +198,63 @@ public isolated client class Client {
     } external;
 
 }
+
+// A TID is split positionally by JCo into four fixed-width character fields, so a shorter
+// value fails inside JCo and a longer one is silently truncated, which would make SAP record a
+// different identifier than the caller believes it used. The content is deliberately not
+// restricted: SAP stores the TID components as CHAR, so an application may derive a TID from
+// its own idempotency key.
+isolated function validateTid(string tid) returns Error? {
+    if tid.length() != TID_LENGTH {
+        return error ParameterError(string `Invalid transaction ID '${tid}'. A TID must be exactly `
+                + string `${TID_LENGTH} characters long.`);
+    }
+}
+
+// Unit IDs, unlike TIDs, are 16 bytes in hexadecimal. JCo documents that format but
+// JCo.createFunctionUnit does not enforce it, so a malformed ID would otherwise surface only
+// later when the unit is queried.
+isolated function validateUnitId(string unitId) returns Error? {
+    if !UNIT_ID_PATTERN.isFullMatch(unitId) {
+        return error ParameterError(string `Invalid bgRFC unit ID '${unitId}'. A unit ID must be a `
+                + string `${UNIT_ID_LENGTH}-character hexadecimal string.`);
+    }
+}
+
+isolated function sendTRfcExternal(Client jcoClient, string functionName, RfcParameters parameters,
+        string tid, boolean autoConfirm) returns Error? = @java:Method {
+    name: "sendTRfc",
+    'class: "io.ballerina.lib.sap.Transactions"
+} external;
+
+isolated function sendQRfcExternal(Client jcoClient, string functionName, string queueName,
+        RfcParameters parameters, string tid, boolean autoConfirm) returns Error? = @java:Method {
+    name: "sendQRfc",
+    'class: "io.ballerina.lib.sap.Transactions"
+} external;
+
+isolated function confirmTidExternal(Client jcoClient, string tid) returns Error? = @java:Method {
+    name: "confirmTid",
+    'class: "io.ballerina.lib.sap.Transactions"
+} external;
+
+isolated function sendBgRfcUnitExternal(Client jcoClient, RemoteFunctionCall[] functionCalls,
+        BgRfcUnitConfig unitConfig) returns BgRfcUnitInfo|Error = @java:Method {
+    name: "sendBgRfcUnit",
+    'class: "io.ballerina.lib.sap.Transactions"
+} external;
+
+isolated function getBgRfcUnitStateExternal(Client jcoClient, BgRfcUnitInfo unit)
+        returns BgRfcUnitState|Error = @java:Method {
+    name: "getBgRfcUnitState",
+    'class: "io.ballerina.lib.sap.Transactions"
+} external;
+
+isolated function confirmBgRfcUnitExternal(Client jcoClient, BgRfcUnitInfo unit)
+        returns Error? = @java:Method {
+    name: "confirmBgRfcUnit",
+    'class: "io.ballerina.lib.sap.Transactions"
+} external;
 
 isolated function initializeClient(Client jcoClient, AdvancedConfig config, string destinationId) returns Error? = @java:Method {
     'class: "io.ballerina.lib.sap.Client"

--- a/ballerina/tests/bgrfc_test.bal
+++ b/ballerina/tests/bgrfc_test.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/ballerina/tests/bgrfc_test.bal
+++ b/ballerina/tests/bgrfc_test.bal
@@ -27,8 +27,8 @@ import ballerina/uuid;
 // All tests are disabled by default. Set the required environment variables
 // (see config.bal) to enable them.
 
-const string BGRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
-const string BGRFC_QUEUE = "BAL_JCO_BGRFC_QUEUE";
+const BGRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
+const BGRFC_QUEUE = "BAL_JCO_BGRFC_QUEUE";
 
 isolated function unitCall(string tag) returns FunctionCall {
     return {

--- a/ballerina/tests/bgrfc_test.bal
+++ b/ballerina/tests/bgrfc_test.bal
@@ -38,15 +38,8 @@ isolated function unitCall(string tag) returns FunctionCall {
 }
 
 // A 32-character hexadecimal unit ID, unique per run.
-isolated function newUnitId() returns string {
-    string id = "";
-    foreach string:Char c in uuid:createType4AsString() {
-        if c != "-" {
-            id += c;
-        }
-    }
-    return id.toUpperAscii();
-}
+isolated function newUnitId() returns string =>
+        re `-`.replaceAll(uuid:createRandomUuid(), "").toUpperAscii();
 
 // Polls until the unit leaves the in-flight states. COMMITTED is the terminal state from the
 // sender's point of view: CONFIRMED only exists after confirmBgRfcUnit is called, so waiting

--- a/ballerina/tests/bgrfc_test.bal
+++ b/ballerina/tests/bgrfc_test.bal
@@ -30,7 +30,7 @@ import ballerina/uuid;
 const BGRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
 const BGRFC_QUEUE = "BAL_JCO_BGRFC_QUEUE";
 
-isolated function unitCall(string tag) returns FunctionCall {
+isolated function unitCall(string tag) returns RemoteFunctionCall {
     return {
         functionName: BGRFC_FUNCTION,
         parameters: {tableParameters: {"TCPICDAT": [{"LINE": "ballerina-bgrfc " + tag}]}}

--- a/ballerina/tests/bgrfc_test.bal
+++ b/ballerina/tests/bgrfc_test.bal
@@ -1,0 +1,214 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.runtime;
+import ballerina/test;
+import ballerina/uuid;
+
+// Tests for background RFC (bgRFC) units of work: sendBgRfcUnit, getBgRfcUnitState, and
+// confirmBgRfcUnit.
+//
+// Uses STFC_WRITE_TO_TCPIC, a standard SAP basis RFC with no export parameters, which suits
+// asynchronous unit execution.
+//
+// All tests are disabled by default. Set the required environment variables
+// (see config.bal) to enable them.
+
+const string BGRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
+const string BGRFC_QUEUE = "BAL_JCO_BGRFC_QUEUE";
+
+isolated function unitCall(string tag) returns FunctionCall {
+    return {
+        functionName: BGRFC_FUNCTION,
+        parameters: {tableParameters: {"TCPICDAT": [{"LINE": "ballerina-bgrfc " + tag}]}}
+    };
+}
+
+// A 32-character hexadecimal unit ID, unique per run.
+isolated function newUnitId() returns string {
+    string id = "";
+    foreach string:Char c in uuid:createType4AsString() {
+        if c != "-" {
+            id += c;
+        }
+    }
+    return id.toUpperAscii();
+}
+
+// Polls until the unit leaves the in-flight states. COMMITTED is the terminal state from the
+// sender's point of view: CONFIRMED only exists after confirmBgRfcUnit is called, so waiting
+// for it here would never return.
+isolated function awaitUnitProcessing(Client sapClient, BgRfcUnitInfo unit)
+        returns BgRfcUnitState|error {
+    BgRfcUnitState state = NOT_FOUND;
+    foreach int _ in 0 ..< 10 {
+        state = check sapClient->getBgRfcUnitState(unit);
+        if state is COMMITTED|CONFIRMED|ROLLED_BACK {
+            return state;
+        }
+        runtime:sleep(1);
+    }
+    return state;
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testSendBgRfcUnitTypeT() returns error? {
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo unit = check sapClient->sendBgRfcUnit([unitCall("t-1"), unitCall("t-2")],
+            {unitHistory: true});
+    test:assertEquals(unit.unitType, BGRFC_TYPE_T,
+            "A unit without queue names should be type T");
+    test:assertEquals(unit.unitId.length(), 32,
+            "A bgRFC unit ID should be 32 hexadecimal characters");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testSendBgRfcUnitTypeQ() returns error? {
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo unit = check sapClient->sendBgRfcUnit([unitCall("q")],
+            {queueNames: [BGRFC_QUEUE], unitHistory: true});
+    test:assertEquals(unit.unitType, BGRFC_TYPE_Q,
+            "Supplying queue names should make the unit type Q");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testBgRfcUnitLifecycle() returns error? {
+    // commit -> COMMITTED -> confirm -> CONFIRMED is the order SAP defines.
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo unit = check sapClient->sendBgRfcUnit([unitCall("lifecycle")],
+            {unitHistory: true});
+    BgRfcUnitState processed = check awaitUnitProcessing(sapClient, unit);
+    test:assertEquals(processed, COMMITTED,
+            "A processed unit should reach COMMITTED before it is confirmed");
+    check sapClient->confirmBgRfcUnit(unit);
+    BgRfcUnitState confirmed = check sapClient->getBgRfcUnitState(unit);
+    // Without unit history the backend may already have discarded the status record.
+    test:assertTrue(confirmed is CONFIRMED|NOT_FOUND,
+            "After confirmation the unit should report CONFIRMED, or NOT_FOUND once cleaned up");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testExplicitUnitIdIsUsed() returns error? {
+    // A unit ID derived from a business key makes a repeated submission idempotent: SAP
+    // recognises the unit and executes it only once.
+    Client sapClient = check new (destinationConfig);
+    string unitId = newUnitId();
+    BgRfcUnitInfo first = check sapClient->sendBgRfcUnit([unitCall("explicit")],
+            {unitId: unitId, unitHistory: true});
+    test:assertEquals(first.unitId, unitId, "The supplied unit ID should be used");
+
+    BgRfcUnitInfo second = check sapClient->sendBgRfcUnit([unitCall("explicit")],
+            {unitId: unitId, unitHistory: true});
+    test:assertEquals(second.unitId, unitId, "Re-committing the same unit ID should be accepted");
+
+    // The backend must know the unit, which the locally echoed ID alone would not prove.
+    BgRfcUnitState state = check awaitUnitProcessing(sapClient, first);
+    test:assertNotEquals(state, NOT_FOUND,
+            "SAP should have a record of the unit committed under this ID");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testUnitAttributesAccepted() returns error? {
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo unit = check sapClient->sendBgRfcUnit([unitCall("attrs")], {
+        unitHistory: true,
+        commitCheck: true,
+        programName: "BAL_JCO_TEST",
+        transactionCode: "SE38"
+    });
+    BgRfcUnitState state = check awaitUnitProcessing(sapClient, unit);
+    test:assertNotEquals(state, NOT_FOUND,
+            "A unit sent with attributes should exist on the backend");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testDuplicateQueueNameIsAccepted() returns error? {
+    // JCo returns false from addQueueName when the queue is already assigned, which is
+    // harmless and must not fail the call.
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo unit = check sapClient->sendBgRfcUnit([unitCall("dupqueue")],
+            {queueNames: [BGRFC_QUEUE, BGRFC_QUEUE], unitHistory: true});
+    test:assertEquals(unit.unitType, BGRFC_TYPE_Q, "A duplicate queue name should be tolerated");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testInvalidQueueNameRejectedCleanly() returns error? {
+    // SAP allows uppercase letters, digits and underscores only. JCo signals a violation with a
+    // runtime exception, which must surface as an error rather than aborting the call.
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo|Error result = sapClient->sendBgRfcUnit([unitCall("badqueue")],
+            {queueNames: ["not a queue"], unitHistory: true});
+    test:assertTrue(result is Error, "An invalid queue name should be rejected");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testEmptyUnitRejected() returns error? {
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo|Error result = sapClient->sendBgRfcUnit([]);
+    test:assertTrue(result is Error, "A unit with no function calls should be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("at least one function call"), result.message());
+    }
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testUnknownUnitReportsNotFound() returns error? {
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo phantom = {unitId: newUnitId(), unitType: BGRFC_TYPE_T};
+    BgRfcUnitState state = check sapClient->getBgRfcUnitState(phantom);
+    test:assertEquals(state, NOT_FOUND, "A unit that was never sent should report NOT_FOUND");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["bgrfc"]
+}
+function testMalformedUnitIdRejected() returns error? {
+    Client sapClient = check new (destinationConfig);
+    BgRfcUnitInfo malformed = {unitId: "NOT-A-UNIT-ID", unitType: BGRFC_TYPE_T};
+    BgRfcUnitState|Error result = sapClient->getBgRfcUnitState(malformed);
+    test:assertTrue(result is Error, "A malformed unit ID should be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("32-character hexadecimal"), result.message());
+    }
+}

--- a/ballerina/tests/trfc_qrfc_test.bal
+++ b/ballerina/tests/trfc_qrfc_test.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
 //
 // WSO2 LLC. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/ballerina/tests/trfc_qrfc_test.bal
+++ b/ballerina/tests/trfc_qrfc_test.bal
@@ -1,0 +1,198 @@
+// Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+// Tests for the transactional and queued RFC operations: sendTRfc, sendQRfc, and the
+// transaction ID lifecycle (createTid, confirmTid).
+//
+// All tests use standard SAP basis RFCs available on every ECC/S4 system:
+//   STFC_WRITE_TO_TCPIC - writes rows to table TCPIC; has no export parameters, so it is
+//                         suitable for asynchronous delivery where results are discarded
+//
+// All tests are disabled by default. Set the required environment variables
+// (see config.bal) to enable them.
+
+const string TRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
+
+// A queue name that satisfies SAP's naming rules (uppercase letters, digits, underscores).
+const string TEST_QUEUE = "BAL_JCO_TEST_QUEUE";
+
+isolated function tcpicRow(string tag) returns RfcParameters {
+    return {tableParameters: {"TCPICDAT": [{"LINE": "ballerina-test " + tag}]}};
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testCreateTidReturnsUsableTid() returns error? {
+    Client sapClient = check new (destinationConfig);
+    string tid = check sapClient->createTid();
+    test:assertEquals(tid.length(), 24, "A TID created by SAP should be 24 characters long");
+    check sapClient->confirmTid(tid);
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcWithGeneratedTid() returns error? {
+    Client sapClient = check new (destinationConfig);
+    string tid = check sapClient->sendTRfc(TRFC_FUNCTION, tcpicRow("trfc-auto"));
+    test:assertEquals(tid.length(), 24, "sendTRfc should return the 24-character TID it used");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcReusesSuppliedTid() returns error? {
+    // Sending twice under one unconfirmed TID is the exactly-once contract: SAP recognises the
+    // second call as a duplicate and does not execute it again. Both sends must report the
+    // supplied TID so a caller can retry under it.
+    Client sapClient = check new (destinationConfig);
+    string tid = check sapClient->createTid();
+    string first = check sapClient->sendTRfc(TRFC_FUNCTION, tcpicRow("trfc-retry"), tid,
+            autoConfirm = false);
+    string second = check sapClient->sendTRfc(TRFC_FUNCTION, tcpicRow("trfc-retry"), tid,
+            autoConfirm = false);
+    test:assertEquals(first, tid, "The first send should use the supplied TID");
+    test:assertEquals(second, tid, "The retry should reuse the same TID");
+    check sapClient->confirmTid(tid);
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcAcceptsNonHexadecimalTid() returns error? {
+    // SAP stores the TID components as CHAR, so only the length is constrained. An application
+    // may derive a TID from its own idempotency key.
+    Client sapClient = check new (destinationConfig);
+    string tid = "IDEMPOTENCYKEY0000000001";
+    string used = check sapClient->sendTRfc(TRFC_FUNCTION, tcpicRow("trfc-bizkey"), tid,
+            autoConfirm = false);
+    test:assertEquals(used, tid, "A 24-character non-hexadecimal TID should be accepted");
+    check sapClient->confirmTid(tid);
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcRejectsWrongLengthTid() returns error? {
+    Client sapClient = check new (destinationConfig);
+    foreach string badTid in ["TOOSHORT", "THISTIDISFARTOOLONGTOBEVALID"] {
+        string|Error result = sapClient->sendTRfc(TRFC_FUNCTION, tcpicRow("trfc-bad"), badTid);
+        test:assertTrue(result is Error, "A TID of the wrong length should be rejected");
+        if result is Error {
+            test:assertTrue(result.message().includes("24 characters"),
+                    "The error should state the required TID length: " + result.message());
+        }
+    }
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcUnknownFunctionModule() returns error? {
+    Client sapClient = check new (destinationConfig);
+    string|Error result = sapClient->sendTRfc("BAL_NO_SUCH_FUNCTION_MODULE");
+    test:assertTrue(result is Error, "An unknown function module should be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("not found"), result.message());
+    }
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcUndefinedParameter() returns error? {
+    Client sapClient = check new (destinationConfig);
+    string|Error result = sapClient->sendTRfc(TRFC_FUNCTION,
+            {importParameters: {"BAL_NO_SUCH_PARAM": "x"}});
+    test:assertTrue(result is Error, "A parameter the function module does not define should fail");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["qrfc"]
+}
+function testSendQRfcQueuesCall() returns error? {
+    Client sapClient = check new (destinationConfig);
+    string tid = check sapClient->sendQRfc(TRFC_FUNCTION, TEST_QUEUE, tcpicRow("qrfc"));
+    test:assertEquals(tid.length(), 24, "sendQRfc should return the TID it used");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["qrfc"]
+}
+function testSendQRfcEachCallGetsOwnTid() returns error? {
+    // qRFC preserves the order in which calls reach the queue. These sends are sequential, so
+    // the order is defined; each call must still be tracked by its own TID.
+    Client sapClient = check new (destinationConfig);
+    string first = check sapClient->sendQRfc(TRFC_FUNCTION, TEST_QUEUE, tcpicRow("qrfc-1"));
+    string second = check sapClient->sendQRfc(TRFC_FUNCTION, TEST_QUEUE, tcpicRow("qrfc-2"));
+    test:assertNotEquals(first, second, "Each queued call should have a distinct TID");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["qrfc"]
+}
+function testSendQRfcRejectsEmptyQueueName() returns error? {
+    Client sapClient = check new (destinationConfig);
+    string|Error result = sapClient->sendQRfc(TRFC_FUNCTION, "", tcpicRow("qrfc-noqueue"));
+    test:assertTrue(result is Error, "An empty queue name should be rejected");
+    if result is Error {
+        test:assertTrue(result.message().includes("Queue name"), result.message());
+    }
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testTransactionalCallsShareOneClient() returns error? {
+    // execute and the transactional operations must work through the same client instance.
+    Client sapClient = check new (destinationConfig);
+    RfcRecord echo = check sapClient->execute("STFC_CONNECTION",
+            {importParameters: {"REQUTEXT": "mixed"}});
+    test:assertEquals(echo["ECHOTEXT"], "mixed", "execute should still work on this client");
+    string tid = check sapClient->sendTRfc(TRFC_FUNCTION, tcpicRow("mixed"));
+    test:assertEquals(tid.length(), 24, "sendTRfc should work on the same client as execute");
+}
+
+@test:Config {
+    enable: testsEnabled,
+    groups: ["trfc"]
+}
+function testSendTRfcConversionFailureReturnsError() returns error? {
+    // Parameter binding raises ConversionException, a JCoRuntimeException subclass that is
+    // unrelated to JCoException. Without an explicit guard it escapes as a raw Java error and
+    // aborts the call instead of returning a Ballerina error. STFC_STRUCTURE's RFCHEX3 is a RAW
+    // field, and binding a byte array to it inside a structure triggers that conversion failure.
+    Client sapClient = check new (destinationConfig);
+    string|Error result = sapClient->sendTRfc("STFC_STRUCTURE", {
+        importParameters: {"IMPORTSTRUCT": {"RFCHEX3": <byte[]>[1, 2, 3]}}
+    });
+    test:assertTrue(result is Error,
+            "A value that cannot be converted to its ABAP field should return an error");
+}

--- a/ballerina/tests/trfc_qrfc_test.bal
+++ b/ballerina/tests/trfc_qrfc_test.bal
@@ -26,10 +26,10 @@ import ballerina/test;
 // All tests are disabled by default. Set the required environment variables
 // (see config.bal) to enable them.
 
-const string TRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
+const TRFC_FUNCTION = "STFC_WRITE_TO_TCPIC";
 
 // A queue name that satisfies SAP's naming rules (uppercase letters, digits, underscores).
-const string TEST_QUEUE = "BAL_JCO_TEST_QUEUE";
+const TEST_QUEUE = "BAL_JCO_TEST_QUEUE";
 
 isolated function tcpicRow(string tag) returns RfcParameters {
     return {tableParameters: {"TCPICDAT": [{"LINE": "ballerina-test " + tag}]}};

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/lang.regexp;
 import ballerina/time;
 
 # Connection parameters for an SAP RFC destination.
@@ -90,7 +91,7 @@ public type RfcParameters record {|
 |};
 
 # A single function invocation inside a bgRFC unit of work.
-public type FunctionCall record {|
+public type RemoteFunctionCall record {|
     # Name of the RFC-enabled function module to call
     string functionName;
     # Input parameters for the call, organised by category
@@ -125,7 +126,7 @@ public type BgRfcUnitConfig record {|
     # repeated submission idempotent. If omitted, a unique ID is generated.
     string unitId?;
     # Inbound queues the unit is assigned to. Supplying at least one queue makes the unit
-    # type `Q`; otherwise it is type `T`.
+    # type Q; otherwise it is type T.
     string[] queueNames = [];
     # Holds the unit back from processing until it is unlocked in the SAP system
     boolean 'lock = false;
@@ -140,6 +141,15 @@ public type BgRfcUnitConfig record {|
     # Transaction code recorded with the unit
     string transactionCode?;
 |};
+
+# Required length of a transaction ID.
+const int TID_LENGTH = 24;
+
+# Required length of a bgRFC unit ID.
+const int UNIT_ID_LENGTH = 32;
+
+# A bgRFC unit ID is 16 bytes in hexadecimal.
+final regexp:RegExp UNIT_ID_PATTERN = re `[0-9a-fA-F]{32}`;
 
 # Identifies a bgRFC unit that was committed to the SAP system.
 public type BgRfcUnitInfo record {|

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -89,6 +89,66 @@ public type RfcParameters record {|
     map<RfcRecord[]> tableParameters?;
 |};
 
+# A single function invocation inside a bgRFC unit of work.
+public type FunctionCall record {|
+    # Name of the RFC-enabled function module to call
+    string functionName;
+    # Input parameters for the call, organised by category
+    RfcParameters parameters = {};
+|};
+
+# Type of a bgRFC unit: transactional (exactly-once) or queued (exactly-once in order).
+public enum BgRfcUnitType {
+    # Transactional unit, executed exactly once
+    BGRFC_TYPE_T = "T",
+    # Queued unit, executed exactly once and in order within its queues
+    BGRFC_TYPE_Q = "Q"
+};
+
+# Processing state of a bgRFC unit as reported by the SAP system.
+public enum BgRfcUnitState {
+    # The SAP system has no record of the unit
+    NOT_FOUND,
+    # The unit is currently being processed
+    IN_PROCESS,
+    # Processing finished; the unit is ready to be confirmed
+    COMMITTED,
+    # The unit was confirmed by the client
+    CONFIRMED,
+    # Processing failed and the unit was rolled back
+    ROLLED_BACK
+};
+
+# Configuration for a bgRFC unit of work.
+public type BgRfcUnitConfig record {|
+    # A 32-character hexadecimal unit ID. Supply one derived from a business key to make a
+    # repeated submission idempotent. If omitted, a unique ID is generated.
+    string unitId?;
+    # Inbound queues the unit is assigned to. Supplying at least one queue makes the unit
+    # type `Q`; otherwise it is type `T`.
+    string[] queueNames = [];
+    # Holds the unit back from processing until it is unlocked in the SAP system
+    boolean 'lock = false;
+    # Records the unit history in the SAP system
+    boolean unitHistory = false;
+    # Enables kernel tracing for the unit
+    boolean kernelTrace = false;
+    # Checks whether the unit can be processed before committing it
+    boolean commitCheck = false;
+    # Calling program name recorded with the unit
+    string programName?;
+    # Transaction code recorded with the unit
+    string transactionCode?;
+|};
+
+# Identifies a bgRFC unit that was committed to the SAP system.
+public type BgRfcUnitInfo record {|
+    # The 32-character hexadecimal ID of the unit
+    string unitId;
+    # The type of the unit
+    BgRfcUnitType unitType;
+|};
+
 # Error detail for JCo-origin errors, providing the JCo error group and SAP exception key.
 public type JCoErrorDetail record {|
     # JCo error group identifier
@@ -146,6 +206,20 @@ public type ConfigurationError distinct error;
 # Raised when an unexpected error occurs during RFC execution or other runtime operations.
 public type ExecutionError distinct error;
 
+# Error detail for a failed transactional call, carrying the identifier the call was using so
+# that the caller can retry under it without risking a duplicate execution.
+public type TransactionErrorDetail record {|
+    *JCoErrorDetail;
+    # Transaction ID of the failed tRFC or qRFC call, when one had already been created
+    string tid?;
+    # Unit ID of the failed bgRFC unit operation
+    string unitId?;
+|};
+
+# Raised when a transactional call (tRFC, qRFC, or bgRFC) fails. Retrying under the `tid` or
+# `unitId` carried in the detail preserves the exactly-once guarantee.
+public type TransactionError distinct error<TransactionErrorDetail>;
+
 # Represents all errors that can be returned by the SAP JCo connector.
 public type Error ConnectionError|LogonError|ResourceError|SystemError|AbapApplicationError
-    |JCoError|IDocError|ParameterError|ConfigurationError|ExecutionError;
+    |JCoError|IDocError|ParameterError|ConfigurationError|ExecutionError|TransactionError;

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -357,7 +357,7 @@ Background RFC (bgRFC) groups one or more function calls into a single logical u
 
 ```ballerina
 # A single function invocation inside a bgRFC unit of work.
-public type FunctionCall record {|
+public type RemoteFunctionCall record {|
     # Name of the RFC-enabled function module to call
     string functionName;
     # Input parameters for the call, organised by category
@@ -401,7 +401,7 @@ public type BgRfcUnitInfo record {|
 # + functionCalls - The calls that make up the unit
 # + unitConfig - Configuration for the unit
 # + return - The ID and type of the committed unit, or an error if the commit fails
-isolated remote function sendBgRfcUnit(FunctionCall[] functionCalls,
+isolated remote function sendBgRfcUnit(RemoteFunctionCall[] functionCalls,
         BgRfcUnitConfig unitConfig = {}) returns BgRfcUnitInfo|Error
 ```
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -3,7 +3,7 @@
 _Authors_: @RDPerera  
 _Reviewers_: @niveathika, @NipunaRanasinghe, @shafreenAnfar  
 _Created_: 2024/08/28  
-_Updated_: 2026/04/27  
+_Updated_: 2026/08/20  
 _Edition_: Swan Lake
 
 ## Introduction
@@ -28,6 +28,9 @@ The conforming implementation of the specification is released and included in t
        - 2.1.2.1 [Execute a function module via RFC](#2121-execute-a-function-module-via-rfc)
        - 2.1.2.2 [Close the client](#2122-close-the-client)
        - 2.1.2.3 [Send iDocs to an SAP system](#2123-send-idocs-to-an-sap-system)
+       - 2.1.2.4 [Call a function module exactly once via tRFC](#2124-call-a-function-module-exactly-once-via-trfc)
+       - 2.1.2.5 [Call a function module in order via qRFC](#2125-call-a-function-module-in-order-via-qrfc)
+       - 2.1.2.6 [Commit several calls as one unit of work via bgRFC](#2126-commit-several-calls-as-one-unit-of-work-via-bgrfc)
      - 2.1.3 [Data types](#213-data-type-mapping-between-ballerina-and-sap-jco)
    - 2.2 [Listener](#22-listener)
      - 2.2.1 [Configurations](#221-configurations)
@@ -263,6 +266,175 @@ public function main() returns error? {
     io:println("IDocs sent successfully.");
 }
 ```
+
+##### 2.1.2.4 Call a function module exactly once via tRFC
+
+`execute` is a request/response call and therefore carries no delivery guarantee: if the connection drops after SAP has committed but before the response is received, the caller cannot tell whether the call ran. Transactional RFC (tRFC) closes that gap. SAP tracks the call by a transaction ID (TID) and refuses to execute a second call sent under the same TID, so a retry is safe.
+
+```ballerina
+# Calls an RFC-enabled function module as a transactional RFC (tRFC), which the SAP system
+# executes exactly once. The call is asynchronous, so export and table values the function
+# module produces are discarded and only the TID is returned. Use `execute` when the result
+# is needed.
+#
+# + functionName - Name of the RFC function module to call
+# + parameters - Input parameters organised by category
+# + tid - The transaction ID to use. If not provided, one is created automatically. A supplied
+#         TID must be exactly 24 characters long; its content is otherwise unrestricted, so it
+#         may be derived from an application idempotency key.
+# + autoConfirm - Whether to confirm the TID after a successful send
+# + return - The TID the call was sent under, or an error if the send fails
+isolated remote function sendTRfc(string functionName, RfcParameters parameters = {},
+        string? tid = (), boolean autoConfirm = true) returns string|Error
+```
+
+The transaction ID lifecycle is also available directly, for integrations that must survive a process failure:
+
+```ballerina
+# Creates a transaction ID on the SAP system for use with `sendTRfc` or `sendQRfc`.
+isolated remote function createTid() returns string|Error
+
+# Confirms a transaction ID so that the SAP system can discard its record of it.
+#
+# + tid - The TID to confirm. Must be exactly 24 characters long.
+isolated remote function confirmTid(string tid) returns Error?
+```
+
+With the default `autoConfirm = true` the TID is created and confirmed by the connector, which is all a fire-and-forget call needs. Taking control of the lifecycle is what makes delivery survive a crash: if the process dies mid-send there is no error value to inspect, so the identifier must be obtained and persisted *before* the call for a restarted process to resume under it.
+
+```ballerina
+string tid = check sapClient->createTid();
+check persistTid(movementId, tid);
+_ = check sapClient->sendTRfc("Z_POST_GOODS_MOVEMENT", parameters, tid, autoConfirm = false);
+check sapClient->confirmTid(tid);
+```
+
+###### How a transaction ID is generated
+
+A TID is produced in one of two ways, and the connector never invents one itself:
+
+1. **By the SAP system.** `createTid`, and the automatic path taken when `tid` is omitted, both call `JCoDestination.createTID`, so the value is allocated by the SAP system and is guaranteed unique for that destination. It is returned verbatim; the connector does not transform it.
+2. **By the application.** A TID passed in by the caller is used verbatim. Only its length is constrained — exactly 24 characters — because SAP stores the TID components as `CHAR` and applies no format rule of its own. This is what allows a TID to be derived from an application idempotency key.
+
+A caller deriving a TID from a business key needs a rule for reaching 24 characters. Truncating the key itself is unsafe: two operations sharing a prefix would map to the same TID, and SAP would discard the second as a duplicate, losing an update. The recommended derivation is a hash of the canonical business key, hex-encoded in uppercase and truncated to 24 characters:
+
+```ballerina
+string tid = crypto:hashSha256(businessKey.toBytes()).toBase16().toUpperAscii().substring(0, 24);
+```
+
+That retains 96 bits of the digest, which makes an accidental collision negligible, and it is deterministic, so a restarted process derives the same TID from the same key.
+
+A TID is only meaningful on the destination and client that issued it. An application that persists a TID must key its store by destination and client; resuming against a different SAP system would execute the call again.
+
+A confirmed TID must not be reused. Once confirmed, the SAP system forgets it, so a later call sent under that TID is executed again.
+
+When a send fails, the returned `TransactionError` carries the TID in its detail, so the caller can retry under the same identifier without risking a duplicate.
+
+##### 2.1.2.5 Call a function module in order via qRFC
+
+Queued RFC (qRFC) extends the tRFC guarantee with ordering. Calls placed on the same SAP inbound queue are executed exactly once and in the order they were sent, which is required when later updates to a business object must not overtake earlier ones.
+
+```ballerina
+# Calls an RFC-enabled function module as a queued RFC (qRFC). Calls placed on the same
+# inbound queue are executed exactly once and in the order they were sent.
+#
+# + functionName - Name of the RFC function module to call
+# + queueName - The SAP inbound queue that serialises the calls
+# + parameters - Input parameters organised by category
+# + tid - The transaction ID to use. If not provided, one is created automatically.
+# + autoConfirm - Whether to confirm the TID after a successful send
+# + return - The TID the call was sent under, or an error if the send fails
+isolated remote function sendQRfc(string functionName, string queueName,
+        RfcParameters parameters = {}, string? tid = (), boolean autoConfirm = true)
+        returns string|Error
+```
+
+Placing calls on the queue in the correct order is the responsibility of the connector. Draining the queue is a property of the SAP system: entries remain queued until the inbound queue is registered with the QIN scheduler (transaction `SMQR`).
+
+##### 2.1.2.6 Commit several calls as one unit of work via bgRFC
+
+Background RFC (bgRFC) groups one or more function calls into a single logical unit of work, applied together or not at all. This is what keeps related calls, such as a posting and its audit entry, from diverging.
+
+```ballerina
+# A single function invocation inside a bgRFC unit of work.
+public type FunctionCall record {|
+    # Name of the RFC-enabled function module to call
+    string functionName;
+    # Input parameters for the call, organised by category
+    RfcParameters parameters = {};
+|};
+
+# Configuration for a bgRFC unit of work.
+public type BgRfcUnitConfig record {|
+    # A 32-character hexadecimal unit ID. Supply one derived from a business key to make a
+    # repeated submission idempotent. If omitted, a unique ID is generated.
+    string unitId?;
+    # Inbound queues the unit is assigned to. Supplying at least one queue makes the unit
+    # type `Q`; otherwise it is type `T`.
+    string[] queueNames = [];
+    # Holds the unit back from processing until it is unlocked in the SAP system
+    boolean 'lock = false;
+    # Records the unit history in the SAP system
+    boolean unitHistory = false;
+    # Enables kernel tracing for the unit
+    boolean kernelTrace = false;
+    # Checks whether the unit can be processed before committing it
+    boolean commitCheck = false;
+    # Calling program name recorded with the unit
+    string programName?;
+    # Transaction code recorded with the unit
+    string transactionCode?;
+|};
+
+# Identifies a bgRFC unit that was committed to the SAP system.
+public type BgRfcUnitInfo record {|
+    # The 32-character hexadecimal ID of the unit
+    string unitId;
+    # The type of the unit
+    BgRfcUnitType unitType;
+|};
+```
+
+```ballerina
+# Commits one or more function calls to the SAP system as a single bgRFC unit of work.
+#
+# + functionCalls - The calls that make up the unit
+# + unitConfig - Configuration for the unit
+# + return - The ID and type of the committed unit, or an error if the commit fails
+isolated remote function sendBgRfcUnit(FunctionCall[] functionCalls,
+        BgRfcUnitConfig unitConfig = {}) returns BgRfcUnitInfo|Error
+```
+
+A unit is either type `T`, executed exactly once, or type `Q`, executed exactly once and in order within its queues. The type is determined by whether `queueNames` is supplied.
+
+```ballerina
+public enum BgRfcUnitType {
+    BGRFC_TYPE_T = "T",
+    BGRFC_TYPE_Q = "Q"
+}
+```
+
+The processing state of a committed unit can be read and, once processing has finished, confirmed:
+
+```ballerina
+public enum BgRfcUnitState {
+    NOT_FOUND,
+    IN_PROCESS,
+    COMMITTED,
+    CONFIRMED,
+    ROLLED_BACK
+}
+
+# Reads the processing state of a bgRFC unit from the SAP system.
+isolated remote function getBgRfcUnitState(BgRfcUnitInfo unit) returns BgRfcUnitState|Error
+
+# Confirms a bgRFC unit so that the SAP system can delete its status record.
+isolated remote function confirmBgRfcUnit(BgRfcUnitInfo unit) returns Error?
+```
+
+`COMMITTED` is the terminal state from the sender's point of view: it means processing finished and the unit is ready to be confirmed. `CONFIRMED` occurs only after `confirmBgRfcUnit` is called, so waiting for it before confirming would never return. A confirmed unit ID must not be reused.
+
+Supplying a `unitId` derived from a business key makes a repeated submission idempotent, in the same way that reusing a TID does for tRFC: the SAP system recognises the unit and executes it only once.
 
 #### 2.1.3 Data type mapping between Ballerina and SAP JCo
 
@@ -543,7 +715,7 @@ The connector defines distinct error types aligned with Ballerina conventions. A
 
 ```ballerina
 public type Error ConnectionError|LogonError|ResourceError|SystemError|AbapApplicationError
-    |JCoError|IDocError|ParameterError|ConfigurationError|ExecutionError;
+    |JCoError|IDocError|ParameterError|ConfigurationError|ExecutionError|TransactionError;
 ```
 
 | Error type               | Description                                                                                   |
@@ -558,5 +730,6 @@ public type Error ConnectionError|LogonError|ResourceError|SystemError|AbapAppli
 | `ParameterError`         | Raised when an RFC import or export parameter cannot be converted to or from a Ballerina type.|
 | `ConfigurationError`     | Raised during client or listener initialisation and lifecycle management, including calls to `execute` or `sendIDoc` after `close`.|
 | `ExecutionError`         | Raised when an unexpected error occurs during RFC execution or other runtime operations.                                           |
+| `TransactionError`       | Raised when a transactional call (tRFC, qRFC, or bgRFC) fails. Its detail carries the `tid` or `unitId` in use, so the caller can retry under the same identifier without risking a duplicate. |
 
 Most JCo-origin errors carry a `JCoErrorDetail` record with an `errorGroup` integer and an optional `key` string. ABAP application errors additionally carry ABAP message class, type, number, and up to four message variables via `AbapApplicationErrorDetail`.

--- a/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPConstants.java
@@ -43,6 +43,32 @@ public class SAPConstants {
     public static final BString RFC_IMPORT_PARAMETERS = StringUtils.fromString("importParameters");
     public static final BString RFC_TABLE_PARAMETERS = StringUtils.fromString("tableParameters");
 
+    // Transactional RFC (tRFC / qRFC / bgRFC)
+    public static final int TID_LENGTH = 24;
+    public static final int UNIT_ID_LENGTH = 32;
+    public static final String BGRFC_TYPE_T = "T";
+    public static final String BGRFC_TYPE_Q = "Q";
+    public static final String BGRFC_UNIT_INFO_RECORD = "BgRfcUnitInfo";
+
+    // FunctionCall field names
+    public static final BString BGRFC_FUNCTION_NAME = StringUtils.fromString("functionName");
+    public static final BString BGRFC_PARAMETERS = StringUtils.fromString("parameters");
+
+    // BgRfcUnitConfig / BgRfcUnitInfo field names
+    public static final BString BGRFC_UNIT_ID = StringUtils.fromString("unitId");
+    public static final BString BGRFC_UNIT_TYPE = StringUtils.fromString("unitType");
+    public static final BString BGRFC_QUEUE_NAMES = StringUtils.fromString("queueNames");
+    public static final BString BGRFC_LOCK = StringUtils.fromString("lock");
+    public static final BString BGRFC_UNIT_HISTORY = StringUtils.fromString("unitHistory");
+    public static final BString BGRFC_KERNEL_TRACE = StringUtils.fromString("kernelTrace");
+    public static final BString BGRFC_COMMIT_CHECK = StringUtils.fromString("commitCheck");
+    public static final BString BGRFC_PROGRAM_NAME = StringUtils.fromString("programName");
+    public static final BString BGRFC_TRANSACTION_CODE = StringUtils.fromString("transactionCode");
+
+    // TransactionErrorDetail field keys
+    public static final BString DETAIL_TID = StringUtils.fromString("tid");
+    public static final BString DETAIL_UNIT_ID = StringUtils.fromString("unitId");
+
 
     // Class names
     public static final String JCO_STRING = "java.lang.String";
@@ -72,6 +98,7 @@ public class SAPConstants {
     public static final String PARAMETER_ERROR_TYPE         = "ParameterError";
     public static final String CONFIGURATION_ERROR_TYPE     = "ConfigurationError";
     public static final String EXECUTION_ERROR_TYPE         = "ExecutionError";
+    public static final String TRANSACTION_ERROR_TYPE       = "TransactionError";
 
     // JCoErrorDetail field keys
     public static final BString DETAIL_ERROR_GROUP      = StringUtils.fromString("errorGroup");

--- a/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
+++ b/native/src/main/java/io/ballerina/lib/sap/SAPErrorCreator.java
@@ -214,6 +214,31 @@ public class SAPErrorCreator {
     // Private helpers
     // -------------------------------------------------------------------------
 
+    /**
+     * Creates a {@code TransactionError} for a failed tRFC, qRFC, or bgRFC operation, carrying the
+     * identifier the operation was using. The identifier is what makes the delivery repeatable:
+     * retrying under the same TID or unit ID lets SAP recognise the duplicate and execute the call
+     * only once, so it is surfaced to the caller rather than discarded with the exception.
+     *
+     * @param message a human-readable description of what failed
+     * @param e       the originating JCo exception
+     * @param tid     the transaction ID in use, or {@code null} if none had been created
+     * @param unitId  the bgRFC unit ID in use, or {@code null} if not a unit operation
+     * @return a Ballerina {@code TransactionError}
+     */
+    public static BError createTransactionError(String message, JCoException e, String tid, String unitId) {
+        BMap<BString, Object> detail = buildJCoDetail(e.getGroup(), e.getKey());
+        if (tid != null) {
+            detail.put(SAPConstants.DETAIL_TID, StringUtils.fromString(tid));
+        }
+        if (unitId != null) {
+            detail.put(SAPConstants.DETAIL_UNIT_ID, StringUtils.fromString(unitId));
+        }
+        String detailed = message + " " + firstLine(e.getMessage(), "Unknown JCo error");
+        return ErrorCreator.createError(ModuleUtils.getModule(), SAPConstants.TRANSACTION_ERROR_TYPE,
+                StringUtils.fromString(detailed), ErrorCreator.createError(e), detail);
+    }
+
     private static BMap<BString, Object> buildJCoDetail(int errorGroup, String key) {
         BMap<BString, Object> detail = ValueCreator.createMapValue(
                 TypeCreator.createMapType(PredefinedTypes.TYPE_ANYDATA));

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.lib.sap;
+
+import com.sap.conn.jco.JCo;
+import com.sap.conn.jco.JCoBackgroundUnitAttributes;
+import com.sap.conn.jco.JCoDestination;
+import com.sap.conn.jco.JCoException;
+import com.sap.conn.jco.JCoFunction;
+import com.sap.conn.jco.JCoFunctionUnit;
+import com.sap.conn.jco.JCoParameterList;
+import com.sap.conn.jco.JCoRepository;
+import com.sap.conn.jco.JCoUnitIdentifier;
+import io.ballerina.lib.sap.parameterprocessor.ImportParameterProcessor;
+import io.ballerina.runtime.api.creators.ValueCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BMap;
+import io.ballerina.runtime.api.values.BObject;
+import io.ballerina.runtime.api.values.BString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Native implementations of the transactional RFC operations on the Ballerina SAP JCo
+ * {@code Client}: tRFC and qRFC function calls, and bgRFC units of work.
+ * <p>
+ * All three protocols give the caller a guarantee that a plain {@code execute} cannot: the call
+ * is applied exactly once, even if the caller retries because it never learned the outcome of an
+ * earlier attempt. The guarantee is carried by an identifier — a transaction ID (TID) for
+ * tRFC/qRFC, a unit ID for bgRFC — which SAP remembers until the caller confirms it. Each
+ * operation therefore returns or accepts that identifier rather than hiding it.
+ */
+public final class Transactions {
+
+    private static final Logger logger = LoggerFactory.getLogger(Transactions.class);
+
+    private Transactions() {
+    }
+
+    /**
+     * Creates a transaction ID on the SAP system.
+     *
+     * @param client the Ballerina {@code Client} object
+     * @return the TID as a Ballerina string, or a Ballerina {@code Error} on failure
+     */
+    public static Object createTid(BObject client) {
+        try {
+            JCoDestination destination = destinationOf(client);
+            return StringUtils.fromString(destination.createTID());
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.fromJCoException(e);
+        }
+    }
+
+    /**
+     * Confirms a transaction ID so that the SAP system can discard its record of it.
+     *
+     * @param client the Ballerina {@code Client} object
+     * @param tid    the TID to confirm
+     * @return {@code null} on success, or a Ballerina {@code Error} on failure
+     */
+    public static Object confirmTid(BObject client, BString tid) {
+        String tidStr = tid.getValue();
+        try {
+            validateTid(tidStr);
+            destinationOf(client).confirmTID(tidStr);
+            return null;
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError(
+                    "Failed to confirm TID '" + tidStr + "'.", e, tidStr, null);
+        }
+    }
+
+    /**
+     * Executes a function module as a transactional RFC (tRFC).
+     *
+     * @param client       the Ballerina {@code Client} object
+     * @param functionName name of the RFC-enabled function module
+     * @param parameters   the {@code RfcParameters} record holding import and table parameters
+     * @param tid          a caller-supplied TID, or {@code null} to create one
+     * @param autoConfirm  whether to confirm the TID after a successful send
+     * @return the TID the call was sent under, or a Ballerina {@code Error} on failure
+     */
+    public static Object sendTRfc(BObject client, BString functionName, BMap<BString, Object> parameters,
+                                  Object tid, boolean autoConfirm) {
+        return send(client, functionName, parameters, tid, null, autoConfirm);
+    }
+
+    /**
+     * Executes a function module as a queued RFC (qRFC) on the given inbound queue.
+     *
+     * @param client       the Ballerina {@code Client} object
+     * @param functionName name of the RFC-enabled function module
+     * @param queueName    the SAP inbound queue that serialises the calls
+     * @param parameters   the {@code RfcParameters} record holding import and table parameters
+     * @param tid          a caller-supplied TID, or {@code null} to create one
+     * @param autoConfirm  whether to confirm the TID after a successful send
+     * @return the TID the call was sent under, or a Ballerina {@code Error} on failure
+     */
+    public static Object sendQRfc(BObject client, BString functionName, BString queueName,
+                                  BMap<BString, Object> parameters, Object tid, boolean autoConfirm) {
+        String queue = queueName.getValue();
+        if (queue.isEmpty()) {
+            return SAPErrorCreator.createParameterError("Queue name is empty.");
+        }
+        return send(client, functionName, parameters, tid, queue, autoConfirm);
+    }
+
+    private static Object send(BObject client, BString functionName, BMap<BString, Object> parameters,
+                               Object tid, String queueName, boolean autoConfirm) {
+        String tidStr = null;
+        try {
+            if (tid instanceof BString) {
+                validateTid(((BString) tid).getValue());
+            }
+            JCoDestination destination = destinationOf(client);
+            JCoFunction function = prepareFunction(destination, functionName, parameters);
+
+            tidStr = (tid instanceof BString) ? ((BString) tid).getValue() : destination.createTID();
+            if (queueName == null) {
+                function.execute(destination, tidStr);
+            } else {
+                function.execute(destination, tidStr, queueName);
+            }
+            if (autoConfirm) {
+                confirmQuietly(destination, tidStr);
+            }
+            return StringUtils.fromString(tidStr);
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            String protocol = queueName == null ? "tRFC" : "qRFC";
+            return SAPErrorCreator.createTransactionError(
+                    protocol + " call to '" + functionName + "' failed.", e, tidStr, null);
+        }
+    }
+
+    // A confirmation failure does not undo the delivery: the call is already recorded in SAP, and
+    // retrying it would not create a duplicate. Failing the operation here would push the caller
+    // into re-sending something that already succeeded, so this is logged rather than surfaced.
+    private static void confirmQuietly(JCoDestination destination, String tid) {
+        try {
+            destination.confirmTID(tid);
+        } catch (JCoException e) {
+            logger.warn("Call was delivered, but confirming TID {} failed. SAP will discard the TID "
+                    + "record on its own schedule. Cause: {}", tid, e.getMessage());
+        }
+    }
+
+    /**
+     * Commits one or more function calls to SAP as a single bgRFC unit of work.
+     *
+     * @param client        the Ballerina {@code Client} object
+     * @param functionCalls the {@code FunctionCall} records making up the unit
+     * @param unitConfig    the {@code BgRfcUnitConfig} record
+     * @return a {@code BgRfcUnitInfo} record, or a Ballerina {@code Error} on failure
+     */
+    @SuppressWarnings("unchecked")
+    public static Object sendBgRfcUnit(BObject client, BArray functionCalls,
+                                       BMap<BString, Object> unitConfig) {
+        String unitId = null;
+        try {
+            if (functionCalls.size() == 0) {
+                return SAPErrorCreator.createParameterError(
+                        "A bgRFC unit must contain at least one function call.");
+            }
+            JCoDestination destination = destinationOf(client);
+
+            Object configuredId = unitConfig.get(SAPConstants.BGRFC_UNIT_ID);
+            if (configuredId != null) {
+                validateUnitId(configuredId.toString());
+            }
+            JCoBackgroundUnitAttributes attributes = buildAttributes(unitConfig);
+            JCoFunctionUnit unit = (configuredId == null)
+                    ? JCo.createFunctionUnit(attributes)
+                    : JCo.createFunctionUnit(configuredId.toString(), attributes);
+
+            BArray queueNames = (BArray) unitConfig.get(SAPConstants.BGRFC_QUEUE_NAMES);
+            if (queueNames != null) {
+                for (int i = 0; i < queueNames.size(); i++) {
+                    String queue = queueNames.getBString(i).getValue();
+                    if (!unit.addQueueName(queue)) {
+                        return SAPErrorCreator.createParameterError(
+                                "Queue name '" + queue + "' was rejected by JCo.");
+                    }
+                }
+            }
+
+            for (int i = 0; i < functionCalls.size(); i++) {
+                BMap<BString, Object> call = (BMap<BString, Object>) functionCalls.get(i);
+                BString name = (BString) call.get(SAPConstants.BGRFC_FUNCTION_NAME);
+                BMap<BString, Object> params = (BMap<BString, Object>)
+                        call.get(SAPConstants.BGRFC_PARAMETERS);
+                unit.addFunction(prepareFunction(destination, name, params));
+            }
+
+            JCoUnitIdentifier identifier = unit.getIdentifier();
+            unitId = identifier.getID();
+            unit.commit(destination);
+            return createUnitInfo(unitId, identifier.getType());
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError("bgRFC unit commit failed.", e, null, unitId);
+        }
+    }
+
+    /**
+     * Reads the processing state of a bgRFC unit from the SAP system.
+     *
+     * @param client   the Ballerina {@code Client} object
+     * @param unitInfo the {@code BgRfcUnitInfo} record identifying the unit
+     * @return the state name as a Ballerina string, or a Ballerina {@code Error} on failure
+     */
+    public static Object getBgRfcUnitState(BObject client, BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
+        try {
+            JCoUnitIdentifier identifier = toIdentifier(unitInfo);
+            return StringUtils.fromString(destinationOf(client).getFunctionUnitState(identifier).name());
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError(
+                    "Failed to read the state of bgRFC unit '" + unitId + "'.", e, null, unitId);
+        }
+    }
+
+    /**
+     * Confirms a processed bgRFC unit so that SAP can delete its status record.
+     *
+     * @param client   the Ballerina {@code Client} object
+     * @param unitInfo the {@code BgRfcUnitInfo} record identifying the unit
+     * @return {@code null} on success, or a Ballerina {@code Error} on failure
+     */
+    public static Object confirmBgRfcUnit(BObject client, BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
+        try {
+            destinationOf(client).confirmFunctionUnit(toIdentifier(unitInfo));
+            return null;
+        } catch (BError e) {
+            return e;
+        } catch (JCoException e) {
+            return SAPErrorCreator.createTransactionError(
+                    "Failed to confirm bgRFC unit '" + unitId + "'.", e, null, unitId);
+        }
+    }
+
+    /** Looks the function up and binds its import and table parameters, mirroring {@code execute}. */
+    @SuppressWarnings("unchecked")
+    private static JCoFunction prepareFunction(JCoDestination destination, BString functionName,
+                                               BMap<BString, Object> parameters) throws JCoException {
+        String name = functionName.getValue();
+        if (name.isEmpty()) {
+            throw SAPErrorCreator.createParameterError("Function name is empty.");
+        }
+        JCoRepository repository = destination.getRepository();
+        JCoFunction function = repository.getFunction(name);
+        if (function == null) {
+            throw SAPErrorCreator.createParameterError("RFC function '" + name + "' not found in SAP.");
+        }
+        if (parameters == null) {
+            return function;
+        }
+
+        BMap<BString, Object> importParameters =
+                (BMap<BString, Object>) parameters.get(SAPConstants.RFC_IMPORT_PARAMETERS);
+        BMap<BString, Object> tableParameters =
+                (BMap<BString, Object>) parameters.get(SAPConstants.RFC_TABLE_PARAMETERS);
+
+        if (importParameters != null) {
+            JCoParameterList importList = function.getImportParameterList();
+            if (importList == null) {
+                throw SAPErrorCreator.createParameterError("RFC function '" + name
+                        + "' has no import parameters but importParameters were provided.");
+            }
+            ImportParameterProcessor.setImportParams(importList, importParameters);
+        }
+        if (tableParameters != null) {
+            JCoParameterList tableList = function.getTableParameterList();
+            if (tableList == null) {
+                throw SAPErrorCreator.createParameterError("RFC function '" + name
+                        + "' has no table parameters but tableParameters were provided.");
+            }
+            ImportParameterProcessor.setTableParams(tableList, tableParameters);
+        }
+        return function;
+    }
+
+    private static BMap<BString, Object> createUnitInfo(String unitId, JCoUnitIdentifier.Type type) {
+        BMap<BString, Object> info = ValueCreator.createRecordValue(
+                ModuleUtils.getModule(), SAPConstants.BGRFC_UNIT_INFO_RECORD);
+        info.put(SAPConstants.BGRFC_UNIT_ID, StringUtils.fromString(unitId));
+        info.put(SAPConstants.BGRFC_UNIT_TYPE, StringUtils.fromString(
+                type == JCoUnitIdentifier.Type.TYPE_Q ? SAPConstants.BGRFC_TYPE_Q : SAPConstants.BGRFC_TYPE_T));
+        return info;
+    }
+
+    private static JCoUnitIdentifier toIdentifier(BMap<BString, Object> unitInfo) {
+        String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
+        validateUnitId(unitId);
+        JCoUnitIdentifier.Type type =
+                SAPConstants.BGRFC_TYPE_Q.equals(unitField(unitInfo, SAPConstants.BGRFC_UNIT_TYPE))
+                        ? JCoUnitIdentifier.Type.TYPE_Q
+                        : JCoUnitIdentifier.Type.TYPE_T;
+        return JCo.createUnitIdentifier(unitId, type);
+    }
+
+    private static JCoBackgroundUnitAttributes buildAttributes(BMap<BString, Object> unitConfig) {
+        JCoBackgroundUnitAttributes attributes = JCo.createBackgroundUnitAttributes();
+        attributes.setLock(booleanConfig(unitConfig, SAPConstants.BGRFC_LOCK));
+        attributes.setUnitHistory(booleanConfig(unitConfig, SAPConstants.BGRFC_UNIT_HISTORY));
+        attributes.setKernelTrace(booleanConfig(unitConfig, SAPConstants.BGRFC_KERNEL_TRACE));
+        attributes.setCommitCheckOn(booleanConfig(unitConfig, SAPConstants.BGRFC_COMMIT_CHECK));
+        Object programName = unitConfig.get(SAPConstants.BGRFC_PROGRAM_NAME);
+        if (programName != null) {
+            attributes.setProgramName(programName.toString());
+        }
+        Object transactionCode = unitConfig.get(SAPConstants.BGRFC_TRANSACTION_CODE);
+        if (transactionCode != null) {
+            attributes.setTransactionCode(transactionCode.toString());
+        }
+        return attributes;
+    }
+
+    private static boolean booleanConfig(BMap<BString, Object> config, BString key) {
+        Object value = config.get(key);
+        return value instanceof Boolean && (Boolean) value;
+    }
+
+    private static String unitField(BMap<BString, Object> unitInfo, BString field) {
+        Object value = unitInfo.get(field);
+        return value == null ? "" : value.toString();
+    }
+
+    private static JCoDestination destinationOf(BObject client) {
+        JCoDestination destination = (JCoDestination) client.getNativeData(SAPConstants.RFC_DESTINATION);
+        if (destination == null) {
+            throw SAPErrorCreator.createConfigError("Client is closed or not initialized.");
+        }
+        return destination;
+    }
+
+    // JCo splits a TID positionally into four fixed-width character fields, so a shorter value
+    // raises a raw StringIndexOutOfBoundsException and a longer one is silently truncated —
+    // which would break exactly-once, because SAP would record a different identifier than the
+    // caller believes it used. The content is deliberately not restricted: SAP stores the TID
+    // components as CHAR, so an application may derive a TID from its own idempotency key.
+    private static void validateTid(String tid) {
+        if (tid == null || tid.length() != SAPConstants.TID_LENGTH) {
+            throw SAPErrorCreator.createParameterError("Invalid transaction ID '" + tid
+                    + "'. A TID must be exactly " + SAPConstants.TID_LENGTH + " characters long.");
+        }
+    }
+
+    // Unit IDs, unlike TIDs, really are 16 bytes in hexadecimal — JCo documents that and rejects
+    // bad values in createUnitIdentifier. JCo.createFunctionUnit however accepts any length, so a
+    // malformed ID would otherwise surface only later when the unit is queried.
+    private static void validateUnitId(String unitId) {
+        if (!isHexOfLength(unitId, SAPConstants.UNIT_ID_LENGTH)) {
+            throw SAPErrorCreator.createParameterError("Invalid bgRFC unit ID '" + unitId
+                    + "'. A unit ID must be a " + SAPConstants.UNIT_ID_LENGTH
+                    + "-character hexadecimal string.");
+        }
+    }
+
+    private static boolean isHexOfLength(String value, int length) {
+        if (value == null || value.length() != length) {
+            return false;
+        }
+        for (int i = 0; i < length; i++) {
+            char c = value.charAt(i);
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org).
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -26,6 +26,7 @@ import com.sap.conn.jco.JCoFunction;
 import com.sap.conn.jco.JCoFunctionUnit;
 import com.sap.conn.jco.JCoParameterList;
 import com.sap.conn.jco.JCoRepository;
+import com.sap.conn.jco.JCoRuntimeException;
 import com.sap.conn.jco.JCoUnitIdentifier;
 import io.ballerina.lib.sap.parameterprocessor.ImportParameterProcessor;
 import io.ballerina.runtime.api.creators.ValueCreator;
@@ -201,9 +202,14 @@ public final class Transactions {
             if (queueNames != null) {
                 for (int i = 0; i < queueNames.size(); i++) {
                     String queue = queueNames.getBString(i).getValue();
-                    if (!unit.addQueueName(queue)) {
+                    try {
+                        // A false return means the queue is already assigned to this unit, which
+                        // is harmless. An invalid name raises a runtime exception instead, which
+                        // would otherwise escape as an unhandled Java error.
+                        unit.addQueueName(queue);
+                    } catch (JCoRuntimeException e) {
                         return SAPErrorCreator.createParameterError(
-                                "Queue name '" + queue + "' was rejected by JCo.");
+                                "Invalid queue name '" + queue + "': " + e.getMessage());
                     }
                 }
             }

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -57,7 +57,9 @@ public final class Transactions {
     }
 
     /**
-     * Creates a transaction ID on the SAP system.
+     * Obtains a transaction ID from the SAP system. The value is allocated by SAP through
+     * {@code JCoDestination.createTID} and returned verbatim; the connector neither generates
+     * nor transforms it.
      *
      * @param client the Ballerina {@code Client} object
      * @return the TID as a Ballerina string, or a Ballerina {@code Error} on failure
@@ -85,7 +87,6 @@ public final class Transactions {
     public static Object confirmTid(BObject client, BString tid) {
         String tidStr = tid.getValue();
         try {
-            validateTid(tidStr);
             destinationOf(client).confirmTID(tidStr);
             return null;
         } catch (BError e) {
@@ -109,8 +110,8 @@ public final class Transactions {
      * @return the TID the call was sent under, or a Ballerina {@code Error} on failure
      */
     public static Object sendTRfc(BObject client, BString functionName, BMap<BString, Object> parameters,
-                                  Object tid, boolean autoConfirm) {
-        return send(client, functionName, parameters, tid, null, autoConfirm);
+                                  BString tid, boolean autoConfirm) {
+        return send(client, functionName, parameters, tid.getValue(), null, autoConfirm);
     }
 
     /**
@@ -125,25 +126,16 @@ public final class Transactions {
      * @return the TID the call was sent under, or a Ballerina {@code Error} on failure
      */
     public static Object sendQRfc(BObject client, BString functionName, BString queueName,
-                                  BMap<BString, Object> parameters, Object tid, boolean autoConfirm) {
-        String queue = queueName.getValue();
-        if (queue.isEmpty()) {
-            return SAPErrorCreator.createParameterError("Queue name is empty.");
-        }
-        return send(client, functionName, parameters, tid, queue, autoConfirm);
+                                  BMap<BString, Object> parameters, BString tid, boolean autoConfirm) {
+        return send(client, functionName, parameters, tid.getValue(), queueName.getValue(), autoConfirm);
     }
 
     private static Object send(BObject client, BString functionName, BMap<BString, Object> parameters,
-                               Object tid, String queueName, boolean autoConfirm) {
-        String tidStr = null;
+                               String tidStr, String queueName, boolean autoConfirm) {
         try {
-            if (tid instanceof BString) {
-                validateTid(((BString) tid).getValue());
-            }
             JCoDestination destination = destinationOf(client);
             JCoFunction function = prepareFunction(destination, functionName, parameters);
 
-            tidStr = (tid instanceof BString) ? ((BString) tid).getValue() : destination.createTID();
             if (queueName == null) {
                 function.execute(destination, tidStr);
             } else {
@@ -152,7 +144,7 @@ public final class Transactions {
             if (autoConfirm) {
                 confirmQuietly(destination, tidStr);
             }
-            return StringUtils.fromString(tidStr);
+            return null;
         } catch (BError e) {
             return e;
         } catch (JCoException e) {
@@ -193,16 +185,9 @@ public final class Transactions {
                                        BMap<BString, Object> unitConfig) {
         String unitId = null;
         try {
-            if (functionCalls.size() == 0) {
-                return SAPErrorCreator.createParameterError(
-                        "A bgRFC unit must contain at least one function call.");
-            }
             JCoDestination destination = destinationOf(client);
 
             Object configuredId = unitConfig.get(SAPConstants.BGRFC_UNIT_ID);
-            if (configuredId != null) {
-                validateUnitId(configuredId.toString());
-            }
             JCoBackgroundUnitAttributes attributes = buildAttributes(unitConfig);
             JCoFunctionUnit unit = (configuredId == null)
                     ? JCo.createFunctionUnit(attributes)
@@ -344,7 +329,6 @@ public final class Transactions {
 
     private static JCoUnitIdentifier toIdentifier(BMap<BString, Object> unitInfo) {
         String unitId = unitField(unitInfo, SAPConstants.BGRFC_UNIT_ID);
-        validateUnitId(unitId);
         JCoUnitIdentifier.Type type =
                 SAPConstants.BGRFC_TYPE_Q.equals(unitField(unitInfo, SAPConstants.BGRFC_UNIT_TYPE))
                         ? JCoUnitIdentifier.Type.TYPE_Q
@@ -403,39 +387,4 @@ public final class Transactions {
         return destination;
     }
 
-    // JCo splits a TID positionally into four fixed-width character fields, so a shorter value
-    // raises a raw StringIndexOutOfBoundsException and a longer one is silently truncated —
-    // which would break exactly-once, because SAP would record a different identifier than the
-    // caller believes it used. The content is deliberately not restricted: SAP stores the TID
-    // components as CHAR, so an application may derive a TID from its own idempotency key.
-    private static void validateTid(String tid) {
-        if (tid == null || tid.length() != SAPConstants.TID_LENGTH) {
-            throw SAPErrorCreator.createParameterError("Invalid transaction ID '" + tid
-                    + "'. A TID must be exactly " + SAPConstants.TID_LENGTH + " characters long.");
-        }
-    }
-
-    // Unit IDs, unlike TIDs, really are 16 bytes in hexadecimal — JCo documents that and rejects
-    // bad values in createUnitIdentifier. JCo.createFunctionUnit however accepts any length, so a
-    // malformed ID would otherwise surface only later when the unit is queried.
-    private static void validateUnitId(String unitId) {
-        if (!isHexOfLength(unitId, SAPConstants.UNIT_ID_LENGTH)) {
-            throw SAPErrorCreator.createParameterError("Invalid bgRFC unit ID '" + unitId
-                    + "'. A unit ID must be a " + SAPConstants.UNIT_ID_LENGTH
-                    + "-character hexadecimal string.");
-        }
-    }
-
-    private static boolean isHexOfLength(String value, int length) {
-        if (value == null || value.length() != length) {
-            return false;
-        }
-        for (int i = 0; i < length; i++) {
-            char c = value.charAt(i);
-            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/native/src/main/java/io/ballerina/lib/sap/Transactions.java
+++ b/native/src/main/java/io/ballerina/lib/sap/Transactions.java
@@ -70,6 +70,8 @@ public final class Transactions {
             return e;
         } catch (JCoException e) {
             return SAPErrorCreator.fromJCoException(e);
+        } catch (JCoRuntimeException e) {
+            return runtimeFailure(e, null, null, "Failed to create a transaction ID.");
         }
     }
 
@@ -91,6 +93,8 @@ public final class Transactions {
         } catch (JCoException e) {
             return SAPErrorCreator.createTransactionError(
                     "Failed to confirm TID '" + tidStr + "'.", e, tidStr, null);
+        } catch (JCoRuntimeException e) {
+            return runtimeFailure(e, tidStr, null, "Failed to confirm TID '" + tidStr + "'.");
         }
     }
 
@@ -155,6 +159,12 @@ public final class Transactions {
             String protocol = queueName == null ? "tRFC" : "qRFC";
             return SAPErrorCreator.createTransactionError(
                     protocol + " call to '" + functionName + "' failed.", e, tidStr, null);
+        } catch (JCoRuntimeException e) {
+            // JCoRuntimeException is unrelated to JCoException, so the catch above does not cover
+            // it. Parameter binding raises ConversionException, a subclass, for a value that does
+            // not fit its ABAP field; without this the call would abort with a raw Java error.
+            return runtimeFailure(e, tidStr, null,
+                    (queueName == null ? "tRFC" : "qRFC") + " call to '" + functionName + "' failed.");
         }
     }
 
@@ -230,6 +240,10 @@ public final class Transactions {
             return e;
         } catch (JCoException e) {
             return SAPErrorCreator.createTransactionError("bgRFC unit commit failed.", e, null, unitId);
+        } catch (JCoRuntimeException e) {
+            // addFunction, the unit builders and parameter binding all signal invalid input with
+            // a JCoRuntimeException, which the catch above does not cover.
+            return runtimeFailure(e, null, unitId, "bgRFC unit commit failed.");
         }
     }
 
@@ -250,6 +264,9 @@ public final class Transactions {
         } catch (JCoException e) {
             return SAPErrorCreator.createTransactionError(
                     "Failed to read the state of bgRFC unit '" + unitId + "'.", e, null, unitId);
+        } catch (JCoRuntimeException e) {
+            return runtimeFailure(e, null, unitId,
+                    "Failed to read the state of bgRFC unit '" + unitId + "'.");
         }
     }
 
@@ -270,6 +287,8 @@ public final class Transactions {
         } catch (JCoException e) {
             return SAPErrorCreator.createTransactionError(
                     "Failed to confirm bgRFC unit '" + unitId + "'.", e, null, unitId);
+        } catch (JCoRuntimeException e) {
+            return runtimeFailure(e, null, unitId, "Failed to confirm bgRFC unit '" + unitId + "'.");
         }
     }
 
@@ -358,6 +377,22 @@ public final class Transactions {
     private static String unitField(BMap<BString, Object> unitInfo, BString field) {
         Object value = unitInfo.get(field);
         return value == null ? "" : value.toString();
+    }
+
+    // JCo reports invalid input through JCoRuntimeException, which does not extend JCoException
+    // and so is not caught alongside it. ConversionException, raised when a supplied value does
+    // not fit its ABAP field, is the common case. These are all caller-input failures, so they
+    // surface as a ParameterError; any identifier already in play is kept in the message so a
+    // retry can still be traced.
+    private static Object runtimeFailure(JCoRuntimeException e, String tid, String unitId, String context) {
+        StringBuilder message = new StringBuilder(context).append(' ').append(e.getMessage());
+        if (tid != null) {
+            message.append(" (TID ").append(tid).append(')');
+        }
+        if (unitId != null) {
+            message.append(" (unit ").append(unitId).append(')');
+        }
+        return SAPErrorCreator.createParameterError(message.toString());
     }
 
     private static JCoDestination destinationOf(BObject client) {


### PR DESCRIPTION
## Purpose

Adds SAP's transactional RFC protocols — **tRFC**, **qRFC**, and **bgRFC** — for function-module calls.

`execute` calls a function module synchronously, and `sendIDoc` already delivers IDocs over tRFC/qRFC with a TID. Function-module calls, though, still have no delivery guarantee: if the connection drops after SAP has committed but before the response arrives, the caller cannot tell whether the call ran, and retrying may post the same business document twice. These protocols are SAP's answer to that, and they are what integrations posting goods movements, orders, or financial documents need.

## New client operations

| Operation | Protocol | Guarantee |
|---|---|---|
| `sendTRfc(functionName, parameters, tid?, autoConfirm?)` | tRFC | Exactly-once; returns the TID |
| `sendQRfc(functionName, queueName, parameters, tid?, autoConfirm?)` | qRFC | Exactly-once and in order, per inbound queue |
| `sendBgRfcUnit(FunctionCall[], BgRfcUnitConfig)` | bgRFC | One or more calls as a single LUW; type `Q` when `queueNames` is set, else type `T` |
| `getBgRfcUnitState(unit)` / `confirmBgRfcUnit(unit)` | bgRFC | Unit state polling and confirmation |
| `createTid()` / `confirmTid(tid)` | tRFC/qRFC | Explicit TID lifecycle for crash-safe retry |

## Testing

Verified end to end against a live SAP ECC system (release 750, kernel 753), with results read back independently from table `TCPIC` through `RFC_READ_TABLE`:

```
TRFC-ONCE   x1   sent TWICE under one TID, stored ONCE
BIZTID      x1   24-character non-hex business-key TID accepted
BG-T-1 / BG-T-2  same timestamp, sequence 1/2 - one unit of work
(no BAD row)     wrong-length TID rejected before anything is sent
```
